### PR TITLE
storage_engine is deprecated in mysql 5.7.5+

### DIFF
--- a/src/main/resources/org/killbill/billing/plugin/analytics/ddl.sql
+++ b/src/main/resources/org/killbill/billing/plugin/analytics/ddl.sql
@@ -1,4 +1,4 @@
-/*! SET storage_engine=INNODB */;
+/*! SET default_storage_engine=INNODB */;
 
 -- Subscription events
 drop table if exists analytics_subscription_transitions;


### PR DESCRIPTION
storage_engine is deprecated in mysql 5.7.5+, replacing with default_storage_engine.  See [#652](https://github.com/killbill/killbill/issues/652) for more info.  