### PR TITLE
Add usageName to the analytics_invoice_items table.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>analytics-plugin</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>Kill Bill OSGI Analytics bundle</name>
     <description>Kill Bill Analytics plugin</description>

--- a/src/main/java/org/killbill/billing/plugin/analytics/api/BusinessInvoiceItem.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/api/BusinessInvoiceItem.java
@@ -53,6 +53,7 @@ public class BusinessInvoiceItem extends BusinessEntityBase {
     private final String productType;
     private final String productCategory;
     private final String slug;
+    private final String usageName;
     private final String phase;
     private final String billingPeriod;
     private final LocalDate startDate;
@@ -99,6 +100,7 @@ public class BusinessInvoiceItem extends BusinessEntityBase {
         this.productType = businessInvoiceItemBaseModelDao.getProductType();
         this.productCategory = businessInvoiceItemBaseModelDao.getProductCategory();
         this.slug = businessInvoiceItemBaseModelDao.getSlug();
+        this.usageName = businessInvoiceItemBaseModelDao.getUsageName();
         this.phase = businessInvoiceItemBaseModelDao.getPhase();
         this.billingPeriod = businessInvoiceItemBaseModelDao.getBillingPeriod();
         this.startDate = businessInvoiceItemBaseModelDao.getStartDate();
@@ -218,6 +220,10 @@ public class BusinessInvoiceItem extends BusinessEntityBase {
         return slug;
     }
 
+    public String getUsageName() {
+        return usageName;
+    }
+
     public String getPhase() {
         return phase;
     }
@@ -284,6 +290,7 @@ public class BusinessInvoiceItem extends BusinessEntityBase {
         sb.append(", productType='").append(productType).append('\'');
         sb.append(", productCategory='").append(productCategory).append('\'');
         sb.append(", slug='").append(slug).append('\'');
+        sb.append(", usageName='").append(usageName).append('\'');
         sb.append(", phase='").append(phase).append('\'');
         sb.append(", billingPeriod='").append(billingPeriod).append('\'');
         sb.append(", startDate=").append(startDate);
@@ -419,6 +426,9 @@ public class BusinessInvoiceItem extends BusinessEntityBase {
         if (startDate != null ? startDate.compareTo(that.startDate) != 0 : that.startDate != null) {
             return false;
         }
+        if (usageName != null ? !usageName.equals(that.usageName) : that.usageName != null) {
+            return false;
+        }
 
         return true;
     }
@@ -453,6 +463,7 @@ public class BusinessInvoiceItem extends BusinessEntityBase {
         result = 31 * result + (productType != null ? productType.hashCode() : 0);
         result = 31 * result + (productCategory != null ? productCategory.hashCode() : 0);
         result = 31 * result + (slug != null ? slug.hashCode() : 0);
+        result = 31 * result + (usageName != null ? usageName.hashCode() : 0);
         result = 31 * result + (phase != null ? phase.hashCode() : 0);
         result = 31 * result + (billingPeriod != null ? billingPeriod.hashCode() : 0);
         result = 31 * result + (startDate != null ? startDate.hashCode() : 0);

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/model/BusinessInvoiceItemBaseModelDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/model/BusinessInvoiceItemBaseModelDao.java
@@ -74,6 +74,7 @@ public abstract class BusinessInvoiceItemBaseModelDao extends BusinessModelDaoBa
     private String productType;
     private String productCategory;
     private String slug;
+    private String usageName;
     private String phase;
     private String billingPeriod;
     private LocalDate startDate;
@@ -214,6 +215,7 @@ public abstract class BusinessInvoiceItemBaseModelDao extends BusinessModelDaoBa
                                            final String productType,
                                            final String productCategory,
                                            final String slug,
+                                           final String usageName,
                                            final String phase,
                                            final String billingPeriod,
                                            final LocalDate startDate,
@@ -272,6 +274,7 @@ public abstract class BusinessInvoiceItemBaseModelDao extends BusinessModelDaoBa
         this.productType = productType;
         this.productCategory = productCategory;
         this.slug = slug;
+        this.usageName = usageName;
         this.phase = phase;
         this.billingPeriod = billingPeriod;
         this.startDate = startDate;
@@ -326,6 +329,7 @@ public abstract class BusinessInvoiceItemBaseModelDao extends BusinessModelDaoBa
              (plan != null && plan.getProduct() != null) ? plan.getProduct().getCatalogName() : null,
              (plan != null && plan.getProduct().getCategory() != null) ? plan.getProduct().getCategory().toString() : null,
              planPhase != null ? planPhase.getName() : null,
+             invoiceItem.getUsageName(),
              (planPhase != null && planPhase.getPhaseType() != null) ? planPhase.getPhaseType().toString() : null,
              (planPhase != null && planPhase.getRecurring() != null && planPhase.getRecurring().getBillingPeriod() != null) ? planPhase.getRecurring().getBillingPeriod().toString() : null,
              invoiceItem.getStartDate(),
@@ -464,6 +468,10 @@ public abstract class BusinessInvoiceItemBaseModelDao extends BusinessModelDaoBa
         return slug;
     }
 
+    public String getUsageName() {
+        return usageName;
+    }
+
     public String getPhase() {
         return phase;
     }
@@ -532,6 +540,7 @@ public abstract class BusinessInvoiceItemBaseModelDao extends BusinessModelDaoBa
         sb.append(", productType='").append(productType).append('\'');
         sb.append(", productCategory='").append(productCategory).append('\'');
         sb.append(", slug='").append(slug).append('\'');
+        sb.append(", usageName='").append(usageName).append('\'');
         sb.append(", phase='").append(phase).append('\'');
         sb.append(", billingPeriod='").append(billingPeriod).append('\'');
         sb.append(", startDate=").append(startDate);
@@ -673,6 +682,9 @@ public abstract class BusinessInvoiceItemBaseModelDao extends BusinessModelDaoBa
         if (startDate != null ? startDate.compareTo(that.startDate) != 0 : that.startDate != null) {
             return false;
         }
+        if(usageName != null ? !usageName.equals(that.usageName) : that.usageName != null) {
+            return false;
+        }
 
         return true;
     }
@@ -709,6 +721,7 @@ public abstract class BusinessInvoiceItemBaseModelDao extends BusinessModelDaoBa
         result = 31 * result + (productType != null ? productType.hashCode() : 0);
         result = 31 * result + (productCategory != null ? productCategory.hashCode() : 0);
         result = 31 * result + (slug != null ? slug.hashCode() : 0);
+        result = 31 * result + (usageName != null ? usageName.hashCode() : 0);
         result = 31 * result + (phase != null ? phase.hashCode() : 0);
         result = 31 * result + (billingPeriod != null ? billingPeriod.hashCode() : 0);
         result = 31 * result + (startDate != null ? startDate.hashCode() : 0);

--- a/src/main/resources/migration/V20170130000000__add_usage_name.sql
+++ b/src/main/resources/migration/V20170130000000__add_usage_name.sql
@@ -1,0 +1,1 @@
+alter table analytics_invoice_items add usage_name varchar(255) default null after slug;

--- a/src/main/resources/org/killbill/billing/plugin/analytics/dao/BusinessAnalyticsSqlDao.sql.stg
+++ b/src/main/resources/org/killbill/billing/plugin/analytics/dao/BusinessAnalyticsSqlDao.sql.stg
@@ -475,6 +475,7 @@ insert into analytics_invoice_items (
 , product_type
 , product_category
 , slug
+, usage_name
 , phase
 , billing_period
 , start_date
@@ -524,6 +525,7 @@ insert into analytics_invoice_items (
 , :productType
 , :productCategory
 , :slug
+, :usageName
 , :phase
 , :billingPeriod
 , :startDate

--- a/src/main/resources/org/killbill/billing/plugin/analytics/ddl.sql
+++ b/src/main/resources/org/killbill/billing/plugin/analytics/ddl.sql
@@ -326,6 +326,7 @@ create table analytics_invoice_items (
 , product_type varchar(50) default null
 , product_category varchar(50) default null
 , slug varchar(50) default null
+, usage_name varchar(255) default null
 , phase varchar(255) default null
 , billing_period varchar(50) default null
 , start_date date default null

--- a/src/test/java/org/killbill/billing/plugin/analytics/AnalyticsTestSuiteNoDB.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/AnalyticsTestSuiteNoDB.java
@@ -209,6 +209,7 @@ public abstract class AnalyticsTestSuiteNoDB {
         Mockito.when(invoiceItem.getSubscriptionId()).thenReturn(subscriptionId);
         Mockito.when(invoiceItem.getPlanName()).thenReturn(UUID.randomUUID().toString());
         Mockito.when(invoiceItem.getPhaseName()).thenReturn(UUID.randomUUID().toString());
+        Mockito.when(invoiceItem.getUsageName()).thenReturn(UUID.randomUUID().toString());
         Mockito.when(invoiceItem.getRate()).thenReturn(new BigDecimal("1203"));
         Mockito.when(invoiceItem.getLinkedItemId()).thenReturn(linkedItemId);
         Mockito.when(invoiceItem.getCreatedDate()).thenReturn(INVOICE_CREATED_DATE);

--- a/src/test/java/org/killbill/billing/plugin/analytics/dao/model/TestBusinessInvoiceItemModelDao.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/dao/model/TestBusinessInvoiceItemModelDao.java
@@ -101,5 +101,6 @@ public class TestBusinessInvoiceItemModelDao extends AnalyticsTestSuiteNoDB {
         Assert.assertEquals(invoiceItemModelDao.getCurrency(), invoiceItem.getCurrency().toString());
         Assert.assertEquals(invoiceItemModelDao.getLinkedItemId(), invoiceItem.getLinkedItemId());
         Assert.assertEquals(invoiceItemModelDao.getEndDate(), invoiceItem.getEndDate());
+        Assert.assertEquals(invoiceItemModelDao.getUsageName(), invoiceItem.getUsageName());
     }
 }


### PR DESCRIPTION
Add usageName to the `analytics_invoice_items` table.  This change allows users to analyze invoice line items by specific unit - previously you could only see if a line item had an item type of `USAGE`.  

Let me know if pull request needs any modifications - thanks! 😄 