### PR TITLE
Fix for analytics issue #69

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessFactoryBase.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessFactoryBase.java
@@ -535,7 +535,7 @@ public abstract class BusinessFactoryBase {
 
     protected List<TagDefinition> getTagDefinitions(final TenantContext context) throws AnalyticsRefreshException {
         final TagUserApi tagUserApi = getTagUserApi();
-        return tagUserApi.getTagDefinitions(context);
+        return tagUserApi.getTagDefinitions(context, true);
     }
 
     protected AuditLog getTagCreationAuditLog(final UUID tagId, final AccountAuditLogs accountAuditLogs) throws AnalyticsRefreshException {


### PR DESCRIPTION
Fix for analytics issue #69 - npe was thrown when account had a system tag.  Updated TagUserApi to optionally return system tags.