### PR TITLE
Logging improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright 2010-2014 Ning, Inc.
-  ~ Copyright 2014 The Billing Project, LLC
+  ~ Copyright 2014-2018 Groupon, Inc
+  ~ Copyright 2014-2018 The Billing Project, LLC
   ~
-  ~ Ning licenses this file to you under the Apache License, version 2.0
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
   ~ (the "License"); you may not use this file except in compliance with the
   ~ License.  You may obtain a copy of the License at:
   ~
@@ -20,7 +21,7 @@
     <parent>
         <artifactId>killbill-oss-parent</artifactId>
         <groupId>org.kill-bill.billing</groupId>
-        <version>0.142.1</version>
+        <version>0.142.7</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>analytics-plugin</artifactId>
@@ -38,11 +39,6 @@
         <system>Github</system>
         <url>https://github.com/killbill/killbill-analytics-plugin/issues</url>
     </issueManagement>
-    <properties>
-        <!-- More recent versions than the core (JDK1.8+) -->
-        <guava.version>21.0</guava.version>
-        <jackson.version>2.9.5</jackson.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.yaml</groupId>
@@ -380,45 +376,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>jdk18</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <source>1.8</source>
-                            <target>1.8</target>
-                            <showDeprecation>true</showDeprecation>
-                            <showWarnings>true</showWarnings>
-                            <fork>true</fork>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-jar-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>jar</goal>
-                                    <goal>test-jar</goal>
-                                </goals>
-                                <configuration>
-                                    <classifier>jdk18</classifier>
-                                </configuration>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <skipIfEmpty>true</skipIfEmpty>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsActivator.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsActivator.java
@@ -100,17 +100,17 @@ public class AnalyticsActivator extends KillbillActivatorBase {
         final AnalyticsConfiguration globalConfiguration = analyticsConfigurationHandler.createConfigurable(configProperties.getProperties());
         analyticsConfigurationHandler.setDefaultConfigurable(globalConfiguration);
 
-        analyticsListener = new AnalyticsListener(logService, roOSGIkillbillAPI, dataSource, configProperties, executor, killbillClock, analyticsConfigurationHandler, notificationQueueService);
+        analyticsListener = new AnalyticsListener(roOSGIkillbillAPI, dataSource, configProperties, executor, killbillClock, analyticsConfigurationHandler, notificationQueueService);
 
-        jobsScheduler = new JobsScheduler(logService, dataSource, killbillClock, notificationQueueService);
+        jobsScheduler = new JobsScheduler(dataSource, killbillClock, notificationQueueService);
 
         final ReportsConfiguration reportsConfiguration = new ReportsConfiguration(dataSource, jobsScheduler);
 
         final EmbeddedDB.DBEngine dbEngine = getDbEngine();
-        final AnalyticsUserApi analyticsUserApi = new AnalyticsUserApi(logService, roOSGIkillbillAPI, dataSource, configProperties, executor, killbillClock, analyticsConfigurationHandler);
-        reportsUserApi = new ReportsUserApi(logService, roOSGIkillbillAPI, dataSource, configProperties, dbEngine, reportsConfiguration, jobsScheduler);
+        final AnalyticsUserApi analyticsUserApi = new AnalyticsUserApi(roOSGIkillbillAPI, dataSource, configProperties, executor, killbillClock, analyticsConfigurationHandler);
+        reportsUserApi = new ReportsUserApi(roOSGIkillbillAPI, dataSource, configProperties, dbEngine, reportsConfiguration, jobsScheduler);
 
-        final ServletRouter servletRouter = new ServletRouter(analyticsUserApi, reportsUserApi, logService);
+        final ServletRouter servletRouter = new ServletRouter(analyticsUserApi, reportsUserApi);
         registerServlet(context, servletRouter);
         registerHandlers();
         registerHealthcheck(context, new AnalyticsHealthcheck(analyticsListener, jobsScheduler));

--- a/src/main/java/org/killbill/billing/plugin/analytics/api/user/AnalyticsUserApi.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/api/user/AnalyticsUserApi.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -24,7 +25,6 @@ import java.util.concurrent.Executor;
 import org.killbill.billing.osgi.libs.killbill.OSGIConfigPropertiesService;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
-import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.plugin.analytics.AnalyticsRefreshException;
 import org.killbill.billing.plugin.analytics.api.BusinessAccount;
 import org.killbill.billing.plugin.analytics.api.BusinessAccountTransition;
@@ -43,11 +43,13 @@ import org.killbill.billing.plugin.analytics.dao.factory.BusinessContextFactory;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.TenantContext;
 import org.killbill.clock.Clock;
-import org.osgi.service.log.LogService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AnalyticsUserApi {
 
-    private final OSGIKillbillLogService logService;
+    private static final Logger logger = LoggerFactory.getLogger(AnalyticsUserApi.class);
+
     private final OSGIKillbillAPI osgiKillbillAPI;
     private final OSGIConfigPropertiesService osgiConfigPropertiesService;
     private final Clock clock;
@@ -56,21 +58,19 @@ public class AnalyticsUserApi {
     private final AllBusinessObjectsDao allBusinessObjectsDao;
     private final CurrencyConversionDao currencyConversionDao;
 
-    public AnalyticsUserApi(final OSGIKillbillLogService logService,
-                            final OSGIKillbillAPI osgiKillbillAPI,
+    public AnalyticsUserApi(final OSGIKillbillAPI osgiKillbillAPI,
                             final OSGIKillbillDataSource osgiKillbillDataSource,
                             final OSGIConfigPropertiesService osgiConfigPropertiesService,
                             final Executor executor,
                             final Clock clock,
                             final AnalyticsConfigurationHandler analyticsConfigurationHandler) {
-        this.logService = logService;
         this.osgiKillbillAPI = osgiKillbillAPI;
         this.osgiConfigPropertiesService = osgiConfigPropertiesService;
         this.clock = clock;
         this.analyticsConfigurationHandler = analyticsConfigurationHandler;
-        this.analyticsDao = new AnalyticsDao(logService, osgiKillbillAPI, osgiKillbillDataSource);
-        this.allBusinessObjectsDao = new AllBusinessObjectsDao(logService, osgiKillbillAPI, osgiKillbillDataSource, executor, clock);
-        this.currencyConversionDao = new CurrencyConversionDao(logService, osgiKillbillDataSource);
+        this.analyticsDao = new AnalyticsDao(osgiKillbillAPI, osgiKillbillDataSource);
+        this.allBusinessObjectsDao = new AllBusinessObjectsDao(osgiKillbillDataSource, executor);
+        this.currencyConversionDao = new CurrencyConversionDao(osgiKillbillDataSource);
     }
 
     public BusinessSnapshot getBusinessSnapshot(final UUID accountId, final TenantContext context) {
@@ -108,9 +108,9 @@ public class AnalyticsUserApi {
 
     public void rebuildAnalyticsForAccount(final UUID accountId, final CallContext context) throws AnalyticsRefreshException {
         final BusinessContextFactory businessContextFactory = new BusinessContextFactory(accountId, context, currencyConversionDao, osgiKillbillAPI, osgiConfigPropertiesService, clock, analyticsConfigurationHandler);
-        logService.log(LogService.LOG_INFO, "Starting Analytics refresh for account " + businessContextFactory.getAccountId());
+        logger.info("Starting Analytics refresh for account {}", businessContextFactory.getAccountId());
         // TODO Should we take the account lock?
         allBusinessObjectsDao.update(businessContextFactory);
-        logService.log(LogService.LOG_INFO, "Finished Analytics refresh for account " + businessContextFactory.getAccountId());
+        logger.info("Finished Analytics refresh for account {}", businessContextFactory.getAccountId());
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/AnalyticsDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/AnalyticsDao.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -28,7 +29,6 @@ import java.util.UUID;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
-import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.plugin.analytics.api.BusinessAccount;
 import org.killbill.billing.plugin.analytics.api.BusinessAccountTransition;
 import org.killbill.billing.plugin.analytics.api.BusinessBundle;
@@ -58,10 +58,9 @@ public class AnalyticsDao extends BusinessAnalyticsDaoBase {
 
     private final OSGIKillbillAPI osgiKillbillAPI;
 
-    public AnalyticsDao(final OSGIKillbillLogService logService,
-                        final OSGIKillbillAPI osgiKillbillAPI,
+    public AnalyticsDao(final OSGIKillbillAPI osgiKillbillAPI,
                         final OSGIKillbillDataSource osgiKillbillDataSource) {
-        super(logService, osgiKillbillDataSource);
+        super(osgiKillbillDataSource);
         this.osgiKillbillAPI = osgiKillbillAPI;
     }
 

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessAccountDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessAccountDao.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -18,28 +19,29 @@
 package org.killbill.billing.plugin.analytics.dao;
 
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
-import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.plugin.analytics.AnalyticsRefreshException;
 import org.killbill.billing.plugin.analytics.dao.factory.BusinessAccountFactory;
 import org.killbill.billing.plugin.analytics.dao.factory.BusinessContextFactory;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessAccountModelDao;
 import org.killbill.billing.util.callcontext.CallContext;
-import org.osgi.service.log.LogService;
 import org.skife.jdbi.v2.Transaction;
 import org.skife.jdbi.v2.TransactionStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BusinessAccountDao extends BusinessAnalyticsDaoBase {
 
+    private static final Logger logger = LoggerFactory.getLogger(BusinessAccountDao.class);
+
     private final BusinessAccountFactory bacFactory;
 
-    public BusinessAccountDao(final OSGIKillbillLogService logService,
-                              final OSGIKillbillDataSource osgiKillbillDataSource) {
-        super(logService, osgiKillbillDataSource);
+    public BusinessAccountDao(final OSGIKillbillDataSource osgiKillbillDataSource) {
+        super(osgiKillbillDataSource);
         bacFactory = new BusinessAccountFactory();
     }
 
     public void update(final BusinessContextFactory businessContextFactory) throws AnalyticsRefreshException {
-        logService.log(LogService.LOG_DEBUG, "Starting rebuild of Analytics account for account " + businessContextFactory.getAccountId());
+        logger.debug("Starting rebuild of Analytics account for account {}", businessContextFactory.getAccountId());
 
         // Recompute the account record
         final BusinessAccountModelDao bac = bacFactory.createBusinessAccount(businessContextFactory);
@@ -52,7 +54,7 @@ public class BusinessAccountDao extends BusinessAnalyticsDaoBase {
             }
         });
 
-        logService.log(LogService.LOG_DEBUG, "Finished rebuild of Analytics account for account " + businessContextFactory.getAccountId());
+        logger.debug("Finished rebuild of Analytics account for account {}", businessContextFactory.getAccountId());
     }
 
     // Note: computing the BusinessAccountModelDao object is fairly expensive, hence should be done outside of the transaction

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessAccountTransitionDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessAccountTransitionDao.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -20,30 +21,29 @@ package org.killbill.billing.plugin.analytics.dao;
 import java.util.Collection;
 
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
-import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.plugin.analytics.AnalyticsRefreshException;
 import org.killbill.billing.plugin.analytics.dao.factory.BusinessAccountTransitionFactory;
 import org.killbill.billing.plugin.analytics.dao.factory.BusinessContextFactory;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessAccountTransitionModelDao;
 import org.killbill.billing.util.callcontext.CallContext;
-import org.osgi.service.log.LogService;
 import org.skife.jdbi.v2.Transaction;
 import org.skife.jdbi.v2.TransactionStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BusinessAccountTransitionDao extends BusinessAnalyticsDaoBase {
 
-    private final LogService logService;
+    private static final Logger logger = LoggerFactory.getLogger(BusinessAccountTransitionDao.class);
+
     private final BusinessAccountTransitionFactory bosFactory;
 
-    public BusinessAccountTransitionDao(final OSGIKillbillLogService logService,
-                                        final OSGIKillbillDataSource osgiKillbillDataSource) {
-        super(logService, osgiKillbillDataSource);
-        this.logService = logService;
+    public BusinessAccountTransitionDao(final OSGIKillbillDataSource osgiKillbillDataSource) {
+        super(osgiKillbillDataSource);
         bosFactory = new BusinessAccountTransitionFactory();
     }
 
     public void update(final BusinessContextFactory businessContextFactory) throws AnalyticsRefreshException {
-        logService.log(LogService.LOG_DEBUG, "Starting rebuild of Analytics account transitions for account " + businessContextFactory.getAccountId());
+        logger.debug("Starting rebuild of Analytics account transitions for account {}", businessContextFactory.getAccountId());
 
         final Collection<BusinessAccountTransitionModelDao> businessAccountTransitions = bosFactory.createBusinessAccountTransitions(businessContextFactory);
 
@@ -55,7 +55,7 @@ public class BusinessAccountTransitionDao extends BusinessAnalyticsDaoBase {
             }
         });
 
-        logService.log(LogService.LOG_DEBUG, "Finished rebuild of Analytics account transitions for account " + businessContextFactory.getAccountId());
+        logger.debug("Finished rebuild of Analytics account transitions for account {}", businessContextFactory.getAccountId());
     }
 
     private void updateInTransaction(final Collection<BusinessAccountTransitionModelDao> businessAccountTransitionModelDaos,

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessAnalyticsDaoBase.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessAnalyticsDaoBase.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -18,20 +19,17 @@
 package org.killbill.billing.plugin.analytics.dao;
 
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
-import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Transaction;
 import org.skife.jdbi.v2.TransactionIsolationLevel;
 
 public class BusinessAnalyticsDaoBase {
 
-    protected final OSGIKillbillLogService logService;
     protected final BusinessAnalyticsSqlDao sqlDao;
 
-    public BusinessAnalyticsDaoBase(final OSGIKillbillLogService logService, final OSGIKillbillDataSource osgiKillbillDataSource) {
+    public BusinessAnalyticsDaoBase(final OSGIKillbillDataSource osgiKillbillDataSource) {
         final DBI dbi = BusinessDBIProvider.get(osgiKillbillDataSource.getDataSource());
         sqlDao = dbi.onDemand(BusinessAnalyticsSqlDao.class);
-        this.logService = logService;
     }
 
     public void executeInTransaction(final Transaction<Void, BusinessAnalyticsSqlDao> transaction) {

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessBundleDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessBundleDao.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -20,15 +21,13 @@ package org.killbill.billing.plugin.analytics.dao;
 import java.util.Collection;
 
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
-import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessBundleModelDao;
 import org.killbill.billing.util.callcontext.CallContext;
 
 public class BusinessBundleDao extends BusinessAnalyticsDaoBase {
 
-    public BusinessBundleDao(final OSGIKillbillLogService logService,
-                             final OSGIKillbillDataSource osgiKillbillDataSource) {
-        super(logService, osgiKillbillDataSource);
+    public BusinessBundleDao(final OSGIKillbillDataSource osgiKillbillDataSource) {
+        super(osgiKillbillDataSource);
     }
 
     public void updateInTransaction(final Collection<BusinessBundleModelDao> bbss,

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessFieldDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessFieldDao.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -18,29 +19,30 @@
 package org.killbill.billing.plugin.analytics.dao;
 
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
-import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.plugin.analytics.AnalyticsRefreshException;
 import org.killbill.billing.plugin.analytics.dao.factory.BusinessContextFactory;
 import org.killbill.billing.plugin.analytics.dao.factory.BusinessFieldFactory;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessFieldModelDao;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessModelDaosWithAccountAndTenantRecordId;
 import org.killbill.billing.util.callcontext.CallContext;
-import org.osgi.service.log.LogService;
 import org.skife.jdbi.v2.Transaction;
 import org.skife.jdbi.v2.TransactionStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BusinessFieldDao extends BusinessAnalyticsDaoBase {
 
+    private static final Logger logger = LoggerFactory.getLogger(BusinessAnalyticsDaoBase.class);
+
     private final BusinessFieldFactory bFieldFactory;
 
-    public BusinessFieldDao(final OSGIKillbillLogService logService,
-                            final OSGIKillbillDataSource osgiKillbillDataSource) {
-        super(logService, osgiKillbillDataSource);
+    public BusinessFieldDao(final OSGIKillbillDataSource osgiKillbillDataSource) {
+        super(osgiKillbillDataSource);
         bFieldFactory = new BusinessFieldFactory();
     }
 
     public void update(final BusinessContextFactory businessContextFactory) throws AnalyticsRefreshException {
-        logService.log(LogService.LOG_DEBUG, "Starting rebuild of Analytics custom fields for account " + businessContextFactory.getAccountId());
+        logger.debug("Starting rebuild of Analytics custom fields for account {}", businessContextFactory.getAccountId());
 
         final BusinessModelDaosWithAccountAndTenantRecordId<BusinessFieldModelDao> fieldModelDaos = bFieldFactory.createBusinessFields(businessContextFactory);
 
@@ -52,7 +54,7 @@ public class BusinessFieldDao extends BusinessAnalyticsDaoBase {
             }
         });
 
-        logService.log(LogService.LOG_DEBUG, "Finished rebuild of Analytics custom fields for account " + businessContextFactory.getAccountId());
+        logger.debug("Finished rebuild of Analytics custom fields for account {}", businessContextFactory.getAccountId());
     }
 
     private void updateInTransaction(final BusinessModelDaosWithAccountAndTenantRecordId<BusinessFieldModelDao> fieldModelDaos,

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessInvoiceDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessInvoiceDao.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
-import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessAccountModelDao;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessInvoiceItemBaseModelDao;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessInvoiceModelDao;
@@ -32,8 +31,8 @@ import com.google.common.collect.Multimap;
 
 public class BusinessInvoiceDao extends BusinessAnalyticsDaoBase {
 
-    public BusinessInvoiceDao(final OSGIKillbillLogService logService, final OSGIKillbillDataSource osgiKillbillDataSource) {
-        super(logService, osgiKillbillDataSource);
+    public BusinessInvoiceDao(final OSGIKillbillDataSource osgiKillbillDataSource) {
+        super(osgiKillbillDataSource);
     }
 
     /**

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessPaymentDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessPaymentDao.java
@@ -19,15 +19,14 @@
 package org.killbill.billing.plugin.analytics.dao;
 
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
-import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessAccountModelDao;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessPaymentBaseModelDao;
 import org.killbill.billing.util.callcontext.CallContext;
 
 public class BusinessPaymentDao extends BusinessAnalyticsDaoBase {
 
-    public BusinessPaymentDao(final OSGIKillbillLogService logService, final OSGIKillbillDataSource osgiKillbillDataSource) {
-        super(logService, osgiKillbillDataSource);
+    public BusinessPaymentDao(final OSGIKillbillDataSource osgiKillbillDataSource) {
+        super(osgiKillbillDataSource);
     }
 
     /**

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessSubscriptionTransitionDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessSubscriptionTransitionDao.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -21,7 +22,6 @@ import java.util.Collection;
 import java.util.concurrent.Executor;
 
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
-import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.plugin.analytics.AnalyticsRefreshException;
 import org.killbill.billing.plugin.analytics.dao.factory.BusinessAccountFactory;
 import org.killbill.billing.plugin.analytics.dao.factory.BusinessBundleFactory;
@@ -31,11 +31,14 @@ import org.killbill.billing.plugin.analytics.dao.model.BusinessAccountModelDao;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessBundleModelDao;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessSubscriptionTransitionModelDao;
 import org.killbill.billing.util.callcontext.CallContext;
-import org.osgi.service.log.LogService;
 import org.skife.jdbi.v2.Transaction;
 import org.skife.jdbi.v2.TransactionStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BusinessSubscriptionTransitionDao extends BusinessAnalyticsDaoBase {
+
+    private static final Logger logger = LoggerFactory.getLogger(BusinessSubscriptionTransitionDao.class);
 
     private final BusinessAccountDao businessAccountDao;
     private final BusinessBundleDao businessBundleDao;
@@ -43,20 +46,19 @@ public class BusinessSubscriptionTransitionDao extends BusinessAnalyticsDaoBase 
     private final BusinessBundleFactory bbsFactory;
     private final BusinessSubscriptionTransitionFactory bstFactory;
 
-    public BusinessSubscriptionTransitionDao(final OSGIKillbillLogService logService,
-                                             final OSGIKillbillDataSource osgiKillbillDataSource,
+    public BusinessSubscriptionTransitionDao(final OSGIKillbillDataSource osgiKillbillDataSource,
                                              final BusinessAccountDao businessAccountDao,
                                              final Executor executor) {
-        super(logService, osgiKillbillDataSource);
+        super(osgiKillbillDataSource);
         this.businessAccountDao = businessAccountDao;
-        this.businessBundleDao = new BusinessBundleDao(logService, osgiKillbillDataSource);
+        this.businessBundleDao = new BusinessBundleDao(osgiKillbillDataSource);
         bacFactory = new BusinessAccountFactory();
         bbsFactory = new BusinessBundleFactory(executor);
         bstFactory = new BusinessSubscriptionTransitionFactory();
     }
 
     public void update(final BusinessContextFactory businessContextFactory) throws AnalyticsRefreshException {
-        logService.log(LogService.LOG_DEBUG, "Starting rebuild of Analytics subscriptions for account " + businessContextFactory.getAccountId());
+        logger.debug("Starting rebuild of Analytics subscriptions for account {}", businessContextFactory.getAccountId());
 
         // Recompute the account record
         final BusinessAccountModelDao bac = bacFactory.createBusinessAccount(businessContextFactory);
@@ -74,7 +76,7 @@ public class BusinessSubscriptionTransitionDao extends BusinessAnalyticsDaoBase 
             }
         });
 
-        logService.log(LogService.LOG_DEBUG, "Finished rebuild of Analytics subscriptions for account " + businessContextFactory.getAccountId());
+        logger.debug("Finished rebuild of Analytics subscriptions for account {}", businessContextFactory.getAccountId());
     }
 
     private void updateInTransaction(final BusinessAccountModelDao bac,

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessTagDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessTagDao.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -18,29 +19,30 @@
 package org.killbill.billing.plugin.analytics.dao;
 
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
-import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.plugin.analytics.AnalyticsRefreshException;
 import org.killbill.billing.plugin.analytics.dao.factory.BusinessContextFactory;
 import org.killbill.billing.plugin.analytics.dao.factory.BusinessTagFactory;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessModelDaosWithAccountAndTenantRecordId;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessTagModelDao;
 import org.killbill.billing.util.callcontext.CallContext;
-import org.osgi.service.log.LogService;
 import org.skife.jdbi.v2.Transaction;
 import org.skife.jdbi.v2.TransactionStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BusinessTagDao extends BusinessAnalyticsDaoBase {
 
+    private static final Logger logger = LoggerFactory.getLogger(BusinessTagDao.class);
+
     private final BusinessTagFactory bTagFactory;
 
-    public BusinessTagDao(final OSGIKillbillLogService logService,
-                          final OSGIKillbillDataSource osgiKillbillDataSource) {
-        super(logService, osgiKillbillDataSource);
+    public BusinessTagDao(final OSGIKillbillDataSource osgiKillbillDataSource) {
+        super(osgiKillbillDataSource);
         bTagFactory = new BusinessTagFactory();
     }
 
     public void update(final BusinessContextFactory businessContextFactory) throws AnalyticsRefreshException {
-        logService.log(LogService.LOG_DEBUG, "Starting rebuild of Analytics tags for account " + businessContextFactory.getAccountId());
+        logger.debug("Starting rebuild of Analytics tags for account {}", businessContextFactory.getAccountId());
 
         final BusinessModelDaosWithAccountAndTenantRecordId<BusinessTagModelDao> tagModelDaos = bTagFactory.createBusinessTags(businessContextFactory);
 
@@ -52,7 +54,7 @@ public class BusinessTagDao extends BusinessAnalyticsDaoBase {
             }
         });
 
-        logService.log(LogService.LOG_DEBUG, "Finished rebuild of Analytics tags for account " + businessContextFactory.getAccountId());
+        logger.debug("Finished rebuild of Analytics tags for account {}", businessContextFactory.getAccountId());
     }
 
     private void updateInTransaction(final BusinessModelDaosWithAccountAndTenantRecordId<BusinessTagModelDao> tagModelDaos,

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/CurrencyConversionDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/CurrencyConversionDao.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -26,17 +27,14 @@ import java.util.Map;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
-import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.plugin.analytics.dao.model.CurrencyConversionModelDao;
 import org.skife.jdbi.v2.DBI;
 
 public class CurrencyConversionDao {
 
-    private final OSGIKillbillLogService logService;
     private final CurrencyConversionSqlDao sqlDao;
 
-    public CurrencyConversionDao(final OSGIKillbillLogService logService, final OSGIKillbillDataSource osgiKillbillDataSource) {
-        this.logService = logService;
+    public CurrencyConversionDao(final OSGIKillbillDataSource osgiKillbillDataSource) {
         final DBI dbi = BusinessDBIProvider.get(osgiKillbillDataSource.getDataSource());
         this.sqlDao = dbi.onDemand(CurrencyConversionSqlDao.class);
     }

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessFactoryBase.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessFactoryBase.java
@@ -137,8 +137,8 @@ public abstract class BusinessFactoryBase {
 
         try {
             return accountUserApi.getAccountById(accountId, context);
-        } catch (AccountApiException e) {
-            logger.warn("Error retrieving account for id " + accountId, e);
+        } catch (final AccountApiException e) {
+            logger.warn("Error retrieving account for id {}", accountId, e);
             throw new AnalyticsRefreshException(e);
         }
     }
@@ -156,7 +156,7 @@ public abstract class BusinessFactoryBase {
             }
         }
 
-        logger.warn("Unable to find Account creation audit log for id " + accountId);
+        logger.warn("Unable to find Account creation audit log for id {}", accountId);
         return null;
     }
 
@@ -202,8 +202,8 @@ public abstract class BusinessFactoryBase {
 
         try {
             return subscriptionApi.getSubscriptionBundlesForAccountId(accountId, context);
-        } catch (SubscriptionApiException e) {
-            logger.warn("Error retrieving bundles for account id " + accountId, e);
+        } catch (final SubscriptionApiException e) {
+            logger.warn("Error retrieving bundles for account id {}",  accountId, e);
             throw new AnalyticsRefreshException(e);
         }
     }
@@ -217,8 +217,8 @@ public abstract class BusinessFactoryBase {
                 throw new AnalyticsRefreshException("Unable to retrieve latest bundle for bundle external key " + bundleExternalKey);
             }
             return bundles.get(bundles.size() - 1);
-        } catch (SubscriptionApiException e) {
-            logger.warn("Error retrieving bundles for bundle external key " + bundleExternalKey, e);
+        } catch (final SubscriptionApiException e) {
+            logger.warn("Error retrieving bundles for bundle external key {}",  bundleExternalKey, e);
             throw new AnalyticsRefreshException(e);
         }
     }
@@ -236,7 +236,7 @@ public abstract class BusinessFactoryBase {
             }
         }
 
-        logger.warn("Unable to find Bundle creation audit log for id " + bundleId);
+        logger.warn("Unable to find Bundle creation audit log for id {}", bundleId);
         return null;
     }
 
@@ -248,7 +248,7 @@ public abstract class BusinessFactoryBase {
             }
         }
 
-        logger.warn("Unable to find Subscription event creation audit log for id " + subscriptionEventId);
+        logger.warn("Unable to find Subscription event creation audit log for id {}", subscriptionEventId);
         return null;
     }
 
@@ -269,7 +269,7 @@ public abstract class BusinessFactoryBase {
             }
         }
 
-        logger.warn("Unable to find Blocking state creation audit log for id " + blockingStateId);
+        logger.warn("Unable to find Blocking state creation audit log for id {}", blockingStateId);
         return null;
     }
 
@@ -290,7 +290,7 @@ public abstract class BusinessFactoryBase {
             }
         }
 
-        logger.warn("Unable to find Invoice creation audit log for id " + invoiceId);
+        logger.warn("Unable to find Invoice creation audit log for id {}", invoiceId);
         return null;
     }
 
@@ -307,7 +307,7 @@ public abstract class BusinessFactoryBase {
             }
         }
 
-        logger.warn("Unable to find Invoice item creation audit log for id " + invoiceItemId);
+        logger.warn("Unable to find Invoice item creation audit log for id {}", invoiceItemId);
         return null;
     }
 
@@ -331,7 +331,7 @@ public abstract class BusinessFactoryBase {
             // Find the catalog when the invoice item was created (same logic as InvoiceItemFactory)
             return catalog.findPlan(invoiceItem.getPlanName(), invoiceItem.getCreatedDate());
         } catch (final CatalogApiException e) {
-            logger.warn("Unable to retrieve plan for invoice item " + invoiceItem.getId(), e);
+            logger.warn("Unable to retrieve plan for invoice item {}",  invoiceItem.getId(), e);
             return null;
         }
     }
@@ -346,7 +346,7 @@ public abstract class BusinessFactoryBase {
         try {
             return plan.findPhase(invoiceItem.getPhaseName());
         } catch (final CatalogApiException e) {
-            logger.warn("Unable to retrieve phase for invoice item " + invoiceItem.getId(), e);
+            logger.warn("Unable to retrieve phase for invoice item {}",  invoiceItem.getId(), e);
             return null;
         }
     }
@@ -359,7 +359,7 @@ public abstract class BusinessFactoryBase {
         final CatalogUserApi catalogUserApi = getCatalogUserApi();
         try {
             return catalogUserApi.getCatalog(null, null, context);
-        } catch (CatalogApiException e) {
+        } catch (final CatalogApiException e) {
             throw new AnalyticsRefreshException(e);
         }
     }
@@ -388,7 +388,7 @@ public abstract class BusinessFactoryBase {
             }
         }
 
-        logger.warn("Unable to find Invoice payment creation audit log for id " + invoicePaymentId);
+        logger.warn("Unable to find Invoice payment creation audit log for id {}", invoicePaymentId);
         return null;
     }
 
@@ -407,20 +407,20 @@ public abstract class BusinessFactoryBase {
         final PaymentApi paymentApi = getPaymentUserApi();
         try {
             return paymentApi.getAccountPayments(accountId, true, false, PLUGIN_PROPERTIES, context);
-        } catch (PaymentApiException e) {
+        } catch (final PaymentApiException e) {
             error = e;
             if (e.getCode() == ErrorCode.PAYMENT_NO_SUCH_PAYMENT_PLUGIN.getCode()) {
                 logger.warn(e.getMessage() + ". Analytics tables will be missing plugin specific information");
 
                 try {
                     return paymentApi.getAccountPayments(accountId, false, false, PLUGIN_PROPERTIES, context);
-                } catch (PaymentApiException e1) {
+                } catch (final PaymentApiException e1) {
                     error = e1;
                 }
             }
         }
 
-        logger.warn("Error retrieving payments for account id " + accountId, error);
+        logger.warn("Error retrieving payments for account id {}",  accountId, error);
         throw new AnalyticsRefreshException(error);
     }
 
@@ -430,20 +430,20 @@ public abstract class BusinessFactoryBase {
         final PaymentApi paymentApi = getPaymentUserApi();
         try {
             return paymentApi.getAccountPaymentMethods(accountId, true, true, PLUGIN_PROPERTIES, context);
-        } catch (PaymentApiException e) {
+        } catch (final PaymentApiException e) {
             error = e;
             if (e.getCode() == ErrorCode.PAYMENT_NO_SUCH_PAYMENT_PLUGIN.getCode()) {
                 logger.warn(e.getMessage() + ". Analytics tables will be missing plugin specific information");
 
                 try {
                     return paymentApi.getAccountPaymentMethods(accountId, true, false, PLUGIN_PROPERTIES, context);
-                } catch (PaymentApiException e1) {
+                } catch (final PaymentApiException e1) {
                     error = e1;
                 }
             }
         }
 
-        logger.warn("Error retrieving payment methods for account id " + accountId, error);
+        logger.warn("Error retrieving payment methods for account id {}",  accountId, error);
         throw new AnalyticsRefreshException(error);
     }
 
@@ -455,7 +455,7 @@ public abstract class BusinessFactoryBase {
             }
         }
 
-        logger.warn("Unable to find payment creation audit log for id " + paymentId);
+        logger.warn("Unable to find payment creation audit log for id {}", paymentId);
         return null;
     }
 
@@ -481,7 +481,7 @@ public abstract class BusinessFactoryBase {
             }
         }
 
-        logger.warn("Unable to find Field creation audit log for id " + fieldId);
+        logger.warn("Unable to find Field creation audit log for id {}", fieldId);
         return null;
     }
 
@@ -512,7 +512,7 @@ public abstract class BusinessFactoryBase {
             }
         }
 
-        logger.warn("Unable to find Tag creation audit log for id " + tagId);
+        logger.warn("Unable to find Tag creation audit log for id {}", tagId);
         return null;
     }
 

--- a/src/main/java/org/killbill/billing/plugin/analytics/http/AnalyticsServlet.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/http/AnalyticsServlet.java
@@ -30,13 +30,16 @@ import org.killbill.billing.plugin.analytics.api.BusinessSnapshot;
 import org.killbill.billing.plugin.analytics.api.user.AnalyticsUserApi;
 import org.killbill.billing.plugin.analytics.reports.ReportsUserApi;
 import org.killbill.billing.util.callcontext.CallContext;
-import org.osgi.service.log.LogService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // Handle /plugins/killbill-analytics/<kbAccountId>
 public class AnalyticsServlet extends BaseServlet {
 
-    public AnalyticsServlet(final AnalyticsUserApi analyticsUserApi, final ReportsUserApi reportsUserApi, final LogService logService) {
-        super(analyticsUserApi, reportsUserApi, logService);
+    private static final Logger logger = LoggerFactory.getLogger(AnalyticsServlet.class);
+
+    public AnalyticsServlet(final AnalyticsUserApi analyticsUserApi, final ReportsUserApi reportsUserApi) {
+        super(analyticsUserApi, reportsUserApi);
     }
 
     @Override
@@ -65,8 +68,8 @@ public class AnalyticsServlet extends BaseServlet {
         try {
             analyticsUserApi.rebuildAnalyticsForAccount(kbAccountId, context);
             resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
-        } catch (AnalyticsRefreshException e) {
-            logService.log(LogService.LOG_ERROR, "Error refreshing account " + kbAccountId, e);
+        } catch (final AnalyticsRefreshException e) {
+            logger.error("Error refreshing account {}", kbAccountId, e);
             resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
         }
     }

--- a/src/main/java/org/killbill/billing/plugin/analytics/http/BaseServlet.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/http/BaseServlet.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2015 Groupon, Inc
- * Copyright 2014-2015 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -29,7 +29,6 @@ import org.killbill.billing.plugin.analytics.api.user.AnalyticsUserApi;
 import org.killbill.billing.plugin.analytics.reports.ReportsUserApi;
 import org.killbill.billing.tenant.api.Tenant;
 import org.killbill.billing.util.callcontext.CallContext;
-import org.osgi.service.log.LogService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -55,12 +54,10 @@ public abstract class BaseServlet extends HttpServlet {
 
     protected final AnalyticsUserApi analyticsUserApi;
     protected final ReportsUserApi reportsUserApi;
-    protected final LogService logService;
 
-    public BaseServlet(final AnalyticsUserApi analyticsUserApi, final ReportsUserApi reportsUserApi, final LogService logService) {
+    public BaseServlet(final AnalyticsUserApi analyticsUserApi, final ReportsUserApi reportsUserApi) {
         this.analyticsUserApi = analyticsUserApi;
         this.reportsUserApi = reportsUserApi;
-        this.logService = logService;
     }
 
     protected void setCrossSiteScriptingHeaders(final HttpServletResponse resp) {

--- a/src/main/java/org/killbill/billing/plugin/analytics/http/ReportsServlet.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/http/ReportsServlet.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2016 Groupon, Inc
- * Copyright 2014-2016 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -46,7 +46,6 @@ import org.killbill.billing.plugin.analytics.reports.analysis.Smoother;
 import org.killbill.billing.plugin.analytics.reports.analysis.Smoother.SmootherType;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.TenantContext;
-import org.osgi.service.log.LogService;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -69,8 +68,8 @@ public class ReportsServlet extends BaseServlet {
     private static final String REPORTS_DATA_FORMAT = "format";
     private static final String REPORT_QUERY_SQL_ONLY = "sqlOnly";
 
-    public ReportsServlet(final AnalyticsUserApi analyticsUserApi, final ReportsUserApi reportsUserApi, final LogService logService) {
-        super(analyticsUserApi, reportsUserApi, logService);
+    public ReportsServlet(final AnalyticsUserApi analyticsUserApi, final ReportsUserApi reportsUserApi) {
+        super(analyticsUserApi, reportsUserApi);
     }
 
     @Override
@@ -82,7 +81,7 @@ public class ReportsServlet extends BaseServlet {
             final ReportConfigurationJson reportConfigurationJson;
             try {
                 reportConfigurationJson = reportsUserApi.getReportConfiguration(reportName, context);
-            } catch (SQLException e) {
+            } catch (final SQLException e) {
                 resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getLocalizedMessage());
                 return;
             }
@@ -106,7 +105,7 @@ public class ReportsServlet extends BaseServlet {
         final ReportConfigurationJson existingReportConfiguration;
         try {
             existingReportConfiguration = reportsUserApi.getReportConfiguration(reportConfigurationJson.getReportName(), context);
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getLocalizedMessage());
             return;
         }
@@ -210,7 +209,7 @@ public class ReportsServlet extends BaseServlet {
     }
 
     static void writeAsCSV(final List<Chart> charts, final OutputStream out) throws IOException {
-        for (Chart cur : charts) {
+        for (final Chart cur : charts) {
             switch (cur.getType()) {
                 case TIMELINE:
                     for (final DataMarker marker : cur.getData()) {

--- a/src/main/java/org/killbill/billing/plugin/analytics/http/ServletRouter.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/http/ServletRouter.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -28,7 +29,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.killbill.billing.plugin.analytics.api.user.AnalyticsUserApi;
 import org.killbill.billing.plugin.analytics.reports.ReportsUserApi;
-import org.osgi.service.log.LogService;
 
 public class ServletRouter extends BaseServlet {
 
@@ -43,11 +43,11 @@ public class ServletRouter extends BaseServlet {
     private final ReportsServlet reportsServlet;
     private final AnalyticsServlet analyticsServlet;
 
-    public ServletRouter(final AnalyticsUserApi analyticsUserApi, final ReportsUserApi reportsUserApi, final LogService logService) {
-        super(analyticsUserApi, reportsUserApi, logService);
-        this.staticServlet = new StaticServlet(analyticsUserApi, reportsUserApi, logService);
-        this.reportsServlet = new ReportsServlet(analyticsUserApi, reportsUserApi, logService);
-        this.analyticsServlet = new AnalyticsServlet(analyticsUserApi, reportsUserApi, logService);
+    public ServletRouter(final AnalyticsUserApi analyticsUserApi, final ReportsUserApi reportsUserApi) {
+        super(analyticsUserApi, reportsUserApi);
+        this.staticServlet = new StaticServlet(analyticsUserApi, reportsUserApi);
+        this.reportsServlet = new ReportsServlet(analyticsUserApi, reportsUserApi);
+        this.analyticsServlet = new AnalyticsServlet(analyticsUserApi, reportsUserApi);
     }
 
     @Override

--- a/src/main/java/org/killbill/billing/plugin/analytics/http/StaticServlet.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/http/StaticServlet.java
@@ -26,15 +26,14 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.killbill.billing.plugin.analytics.api.user.AnalyticsUserApi;
 import org.killbill.billing.plugin.analytics.reports.ReportsUserApi;
-import org.osgi.service.log.LogService;
 
 import com.google.common.io.Resources;
 
 // Handle /plugins/killbill-analytics/static/<resourceName>
 public class StaticServlet extends BaseServlet {
 
-    public StaticServlet(final AnalyticsUserApi analyticsUserApi, final ReportsUserApi reportsUserApi, final LogService logService) {
-        super(analyticsUserApi, reportsUserApi, logService);
+    public StaticServlet(final AnalyticsUserApi analyticsUserApi, final ReportsUserApi reportsUserApi) {
+        super(analyticsUserApi, reportsUserApi);
     }
 
     @Override

--- a/src/main/java/org/killbill/billing/plugin/analytics/reports/ReportsUserApi.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/reports/ReportsUserApi.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2016 Groupon, Inc
- * Copyright 2014-2016 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -40,7 +40,6 @@ import org.killbill.billing.ObjectType;
 import org.killbill.billing.osgi.libs.killbill.OSGIConfigPropertiesService;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
-import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.plugin.analytics.BusinessExecutor;
 import org.killbill.billing.plugin.analytics.dao.BusinessDBIProvider;
 import org.killbill.billing.plugin.analytics.json.Chart;
@@ -63,6 +62,8 @@ import org.killbill.commons.embeddeddb.EmbeddedDB;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.IDBI;
 import org.skife.jdbi.v2.tweak.HandleCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
@@ -75,6 +76,8 @@ import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 
 public class ReportsUserApi {
+
+    private static final Logger logger = LoggerFactory.getLogger(ReportsUserApi.class);
 
     private static final String ANALYTICS_REPORTS_NB_THREADS_PROPERTY = "org.killbill.billing.plugin.analytics.dashboard.nbThreads";
 
@@ -93,8 +96,7 @@ public class ReportsUserApi {
     private final JobsScheduler jobsScheduler;
     private final Metadata sqlMetadata;
 
-    public ReportsUserApi(final OSGIKillbillLogService logService,
-                          final OSGIKillbillAPI killbillAPI,
+    public ReportsUserApi(final OSGIKillbillAPI killbillAPI,
                           final OSGIKillbillDataSource osgiKillbillDataSource,
                           final OSGIConfigPropertiesService osgiConfigPropertiesService,
                           final EmbeddedDB.DBEngine dbEngine,
@@ -117,9 +119,7 @@ public class ReportsUserApi {
                                                                                         }
                                                                                     }
                                                                                    )),
-                                        osgiKillbillDataSource.getDataSource(),
-                                        logService
-        );
+                                        osgiKillbillDataSource.getDataSource());
     }
 
     public void shutdownNow() {

--- a/src/test/java/org/killbill/billing/plugin/analytics/TestAnalyticsListener.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/TestAnalyticsListener.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -26,12 +27,12 @@ public class TestAnalyticsListener extends AnalyticsTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testBlacklist() throws Exception {
-        AnalyticsListener analyticsListener = new AnalyticsListener(logService, killbillAPI, killbillDataSource, osgiConfigPropertiesService, null, clock, analyticsConfigurationHandler, notificationQueueService);
+        AnalyticsListener analyticsListener = new AnalyticsListener(killbillAPI, killbillDataSource, osgiConfigPropertiesService, null, clock, analyticsConfigurationHandler, notificationQueueService);
 
         // No account is blacklisted
         Assert.assertFalse(analyticsListener.isAccountBlacklisted(UUID.randomUUID()));
 
-        analyticsListener = new AnalyticsListener(logService, killbillAPI, killbillDataSource, osgiConfigPropertiesService, null, clock, analyticsConfigurationHandler, notificationQueueService);
+        analyticsListener = new AnalyticsListener(killbillAPI, killbillDataSource, osgiConfigPropertiesService, null, clock, analyticsConfigurationHandler, notificationQueueService);
 
         // Other accounts are blacklisted
         Assert.assertFalse(analyticsListener.isAccountBlacklisted(UUID.randomUUID()));

--- a/src/test/java/org/killbill/billing/plugin/analytics/TestAnalyticsNotificationQueue.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/TestAnalyticsNotificationQueue.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -36,7 +37,7 @@ public class TestAnalyticsNotificationQueue extends AnalyticsTestSuiteWithEmbedd
 
     @Test(groups = "slow")
     public void testSendOneEvent() throws Exception {
-        final AnalyticsListener analyticsListener = new AnalyticsListener(logService, killbillAPI, killbillDataSource, osgiConfigPropertiesService, BusinessExecutor.newCachedThreadPool(osgiConfigPropertiesService), clock, analyticsConfigurationHandler, notificationQueueService);
+        final AnalyticsListener analyticsListener = new AnalyticsListener(killbillAPI, killbillDataSource, osgiConfigPropertiesService, BusinessExecutor.newCachedThreadPool(osgiConfigPropertiesService), clock, analyticsConfigurationHandler, notificationQueueService);
         analyticsListener.start();
 
         // Verify the original state
@@ -61,7 +62,7 @@ public class TestAnalyticsNotificationQueue extends AnalyticsTestSuiteWithEmbedd
 
     @Test(groups = "slow")
     public void testVerifyNoDups() throws Exception {
-        final AnalyticsListener analyticsListener = new AnalyticsListener(logService, killbillAPI, killbillDataSource, osgiConfigPropertiesService, BusinessExecutor.newCachedThreadPool(osgiConfigPropertiesService), clock, analyticsConfigurationHandler, notificationQueueService);
+        final AnalyticsListener analyticsListener = new AnalyticsListener(killbillAPI, killbillDataSource, osgiConfigPropertiesService, BusinessExecutor.newCachedThreadPool(osgiConfigPropertiesService), clock, analyticsConfigurationHandler, notificationQueueService);
         // Don't start the dequeuer
         Assert.assertEquals(Iterables.<NotificationEventWithMetadata>size(analyticsListener.getJobQueue().getFutureNotificationForSearchKeys(accountRecordId, tenantRecordId)), 0);
 

--- a/src/test/java/org/killbill/billing/plugin/analytics/api/user/TestDefaultAnalyticsUserApi.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/api/user/TestDefaultAnalyticsUserApi.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -45,7 +46,7 @@ public class TestDefaultAnalyticsUserApi extends AnalyticsTestSuiteWithEmbeddedD
                                                                                     reportGroup);
         analyticsSqlDao.create(accountModelDao.getTableName(), accountModelDao, callContext);
 
-        final AnalyticsUserApi analyticsUserApi = new AnalyticsUserApi(logService, killbillAPI, killbillDataSource, osgiConfigPropertiesService, BusinessExecutor.newCachedThreadPool(osgiConfigPropertiesService), clock, analyticsConfigurationHandler);
+        final AnalyticsUserApi analyticsUserApi = new AnalyticsUserApi(killbillAPI, killbillDataSource, osgiConfigPropertiesService, BusinessExecutor.newCachedThreadPool(osgiConfigPropertiesService), clock, analyticsConfigurationHandler);
         final BusinessSnapshot businessSnapshot = analyticsUserApi.getBusinessSnapshot(account.getId(), callContext);
         Assert.assertEquals(businessSnapshot.getBusinessAccount(), new BusinessAccount(accountModelDao));
     }

--- a/src/test/java/org/killbill/billing/plugin/analytics/dao/TestAnalyticsDao.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/dao/TestAnalyticsDao.java
@@ -29,7 +29,7 @@ public class TestAnalyticsDao extends AnalyticsTestSuiteWithEmbeddedDB {
 
     @Test(groups = "slow")
     public void testDao() throws Exception {
-        final AnalyticsDao analyticsDao = new AnalyticsDao(logService, killbillAPI, killbillDataSource);
+        final AnalyticsDao analyticsDao = new AnalyticsDao(killbillAPI, killbillDataSource);
         Assert.assertNull(analyticsDao.getAccountById(account.getId(), callContext));
 
         final BusinessAccountModelDao accountModelDao = new BusinessAccountModelDao(account,

--- a/src/test/java/org/killbill/billing/plugin/analytics/dao/TestCurrencyConversionDao.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/dao/TestCurrencyConversionDao.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -29,7 +30,7 @@ public class TestCurrencyConversionDao extends AnalyticsTestSuiteWithEmbeddedDB 
 
     @Test(groups = "slow")
     public void testLookup() throws Exception {
-        final CurrencyConversionDao dao = new CurrencyConversionDao(logService, killbillDataSource);
+        final CurrencyConversionDao dao = new CurrencyConversionDao(killbillDataSource);
 
         final LocalDate effectiveDate = new LocalDate(2012, 1, 1);
         final CurrencyConversionModelDao notFound = dao.getCurrencyConversion("USD", "EUR", effectiveDate);

--- a/src/test/java/org/killbill/billing/plugin/analytics/reports/TestReportsConfiguration.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/reports/TestReportsConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2015 Groupon, Inc
- * Copyright 2014-2015 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -35,7 +35,7 @@ public class TestReportsConfiguration extends AnalyticsTestSuiteWithEmbeddedDB {
 
     @Test(groups = "slow")
     public void testCrud() throws Exception {
-        final JobsScheduler jobsScheduler = new JobsScheduler(logService, killbillDataSource, clock, notificationQueueService);
+        final JobsScheduler jobsScheduler = new JobsScheduler(killbillDataSource, clock, notificationQueueService);
         final ReportsConfiguration reportsConfiguration = new ReportsConfiguration(killbillDataSource, jobsScheduler);
 
         // Verify initial state

--- a/src/test/java/org/killbill/billing/plugin/analytics/reports/scheduler/TestJobsScheduler.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/reports/scheduler/TestJobsScheduler.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -30,7 +31,7 @@ public class TestJobsScheduler extends AnalyticsTestSuiteNoDB {
 
     @BeforeMethod(groups = "fast")
     public void createScheduler() throws Exception {
-        jobsScheduler = new JobsScheduler(logService, killbillDataSource, clock, notificationQueueService);
+        jobsScheduler = new JobsScheduler(killbillDataSource, clock, notificationQueueService);
     }
 
     @Test(groups = "fast")
@@ -51,14 +52,12 @@ public class TestJobsScheduler extends AnalyticsTestSuiteNoDB {
         Assert.assertEquals(computeNextRun(Frequency.DAILY, 15).compareTo(new DateTime(2012, 10, 6, 15, 0, 0)), 0);
     }
 
-
     @Test(groups = "fast")
     public void testComputeHourlyNextRun() throws Exception {
         clock.setTime(new DateTime(2012, 10, 5, 18, 33, 46));
         Assert.assertEquals(computeNextRun(Frequency.HOURLY, 1).compareTo(new DateTime(2012, 10, 5, 19, 5, 0)), 0);
         Assert.assertEquals(computeNextRun(Frequency.HOURLY, null).compareTo(new DateTime(2012, 10, 5, 19, 5, 0)), 0);
     }
-
 
     private DateTime computeNextRun(final Frequency frequency, final Integer refreshHourOfDayGmt) {
         return jobsScheduler.computeNextRun(new AnalyticsReportJob(null, null, null, null, null, frequency, refreshHourOfDayGmt));

--- a/src/test/java/org/killbill/billing/plugin/analytics/reports/scheduler/TestJobsSchedulerWithEmbeddedDB.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/reports/scheduler/TestJobsSchedulerWithEmbeddedDB.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2016 Groupon, Inc
- * Copyright 2016 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -20,6 +20,7 @@ package org.killbill.billing.plugin.analytics.reports.scheduler;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import org.killbill.billing.plugin.analytics.AnalyticsTestSuiteWithEmbeddedDB;
 import org.killbill.billing.plugin.analytics.reports.configuration.ReportsConfigurationModelDao;
 import org.killbill.billing.plugin.analytics.reports.configuration.ReportsConfigurationModelDao.Frequency;
@@ -33,7 +34,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Iterables;
-import org.awaitility.Awaitility;
 
 public class TestJobsSchedulerWithEmbeddedDB extends AnalyticsTestSuiteWithEmbeddedDB {
 
@@ -41,7 +41,7 @@ public class TestJobsSchedulerWithEmbeddedDB extends AnalyticsTestSuiteWithEmbed
 
     @BeforeMethod(groups = "mysql")
     public void createScheduler() throws Exception {
-        jobsScheduler = new JobsScheduler(logService, killbillDataSource, clock, notificationQueueService);
+        jobsScheduler = new JobsScheduler(killbillDataSource, clock, notificationQueueService);
         jobsScheduler.start();
     }
 

--- a/src/test/java/org/killbill/billing/plugin/analytics/reports/sql/TestMetadata.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/reports/sql/TestMetadata.java
@@ -33,7 +33,7 @@ public class TestMetadata extends AnalyticsTestSuiteWithEmbeddedDB {
         final String tableName = "payments_per_day_metadata";
         embeddedDB.executeScript(String.format("create table %s(day datetime, name varchar(100), currency varchar(10), state varchar(10), amount int, fee int);", tableName));
 
-        final Metadata metadata = new Metadata(Sets.<String>newHashSet(tableName), embeddedDB.getDataSource(), logService);
+        final Metadata metadata = new Metadata(Sets.<String>newHashSet(tableName), embeddedDB.getDataSource());
         final Table table = metadata.getTable(tableName).getTable();
 
         Assert.assertEquals(table.fields().length, 6);
@@ -47,7 +47,7 @@ public class TestMetadata extends AnalyticsTestSuiteWithEmbeddedDB {
 
     @Test(groups = {"mysql", "postgresql"})
     public void testTableRetrievalNoReports() throws Exception {
-        final Metadata metadata = new Metadata(Sets.<String>newHashSet(), embeddedDB.getDataSource(), logService);
+        final Metadata metadata = new Metadata(Sets.<String>newHashSet(), embeddedDB.getDataSource());
         Assert.assertNull(metadata.getTable("payments_per_day"));
     }
 }


### PR DESCRIPTION
No need to use `OSGIKillbillLogService` directly anymore. Also, using SLF4J makes it easier to filter things in Splunk (since the logger name is respected).