### PR TITLE
performance: introduce INVOICES group

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -23,6 +23,7 @@
     <inspection_tool class="RedundantTypeArguments" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SizeReplaceableByIsEmpty" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StaticPseudoFunctionalStyleMethod" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="TryWithIdenticalCatches" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TypeMayBeWeakened" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="useRighthandTypeAsWeakestTypeInAssignments" value="true" />
       <option name="useParameterizedTypeForCollectionMethods" value="true" />

--- a/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsJobHierarchy.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsJobHierarchy.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2015 Groupon, Inc
- * Copyright 2015 The Billing Project, LLC
+ * Copyright 2015-2019 Groupon, Inc
+ * Copyright 2015-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -42,6 +42,7 @@ public abstract class AnalyticsJobHierarchy {
                 return Group.OVERDUE;
             case INVOICE_CREATION:
             case INVOICE_ADJUSTMENT:
+                return Group.INVOICES;
             case PAYMENT_SUCCESS:
             case PAYMENT_FAILED:
                 return Group.INVOICE_AND_PAYMENTS;
@@ -56,6 +57,7 @@ public abstract class AnalyticsJobHierarchy {
     public enum Group {
         ALL,
         FIELDS,
+        INVOICES,
         INVOICE_AND_PAYMENTS,
         OVERDUE,
         OTHER,

--- a/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsListener.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsListener.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -39,6 +39,7 @@ import org.killbill.billing.plugin.analytics.dao.BusinessAccountDao;
 import org.killbill.billing.plugin.analytics.dao.BusinessAccountTransitionDao;
 import org.killbill.billing.plugin.analytics.dao.BusinessFieldDao;
 import org.killbill.billing.plugin.analytics.dao.BusinessInvoiceAndPaymentDao;
+import org.killbill.billing.plugin.analytics.dao.BusinessInvoiceDao;
 import org.killbill.billing.plugin.analytics.dao.BusinessSubscriptionTransitionDao;
 import org.killbill.billing.plugin.analytics.dao.CurrencyConversionDao;
 import org.killbill.billing.plugin.analytics.dao.factory.BusinessContextFactory;
@@ -90,6 +91,7 @@ public class AnalyticsListener implements OSGIKillbillEventDispatcher.OSGIKillbi
     private final OSGIKillbillAPI osgiKillbillAPI;
     private final OSGIConfigPropertiesService osgiConfigPropertiesService;
     private final BusinessSubscriptionTransitionDao bstDao;
+    private final BusinessInvoiceDao binDao;
     private final BusinessInvoiceAndPaymentDao binAndBipDao;
     private final BusinessAccountTransitionDao bosDao;
     private final BusinessFieldDao bFieldDao;
@@ -116,6 +118,7 @@ public class AnalyticsListener implements OSGIKillbillEventDispatcher.OSGIKillbi
 
         final BusinessAccountDao bacDao = new BusinessAccountDao(osgiKillbillDataSource);
         this.bstDao = new BusinessSubscriptionTransitionDao(osgiKillbillDataSource, bacDao, executor);
+        this.binDao = new BusinessInvoiceDao(osgiKillbillDataSource, bacDao, executor);
         this.binAndBipDao = new BusinessInvoiceAndPaymentDao(osgiKillbillDataSource, bacDao, executor);
         this.bosDao = new BusinessAccountTransitionDao(osgiKillbillDataSource);
         this.bFieldDao = new BusinessFieldDao(osgiKillbillDataSource);
@@ -296,6 +299,9 @@ public class AnalyticsListener implements OSGIKillbillEventDispatcher.OSGIKillbi
                 break;
             case OVERDUE:
                 bosDao.update(businessContextFactory);
+                break;
+            case INVOICES:
+                binDao.update(job.getObjectId(), businessContextFactory);
                 break;
             case INVOICE_AND_PAYMENTS:
                 binAndBipDao.update(businessContextFactory);

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessAnalyticsSqlDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessAnalyticsSqlDao.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -18,6 +19,7 @@
 package org.killbill.billing.plugin.analytics.dao;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.killbill.billing.plugin.analytics.dao.model.BusinessAccountFieldModelDao;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessAccountModelDao;
@@ -63,6 +65,12 @@ public interface BusinessAnalyticsSqlDao extends Transactional<BusinessAnalytics
     public void create(final String tableName,
                        @BindBean final BusinessModelDaoBase entity,
                        final CallContext callContext);
+
+    @SqlUpdate
+    public void deleteByInvoiceId(@Define("tableName") final String tableName,
+                                  @Bind("invoiceId") final UUID invoiceId,
+                                  @Bind("tenantRecordId") final Long tenantRecordId,
+                                  final CallContext callContext);
 
     @SqlUpdate
     public void deleteByAccountRecordId(@Define("tableName") final String tableName,

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessInvoiceAndPaymentDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessInvoiceAndPaymentDao.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -67,7 +67,7 @@ public class BusinessInvoiceAndPaymentDao extends BusinessAnalyticsDaoBase {
                                         final Executor executor) {
         super(osgiKillbillDataSource);
         this.businessAccountDao = businessAccountDao;
-        this.businessInvoiceDao = new BusinessInvoiceDao(osgiKillbillDataSource);
+        this.businessInvoiceDao = new BusinessInvoiceDao(osgiKillbillDataSource, businessAccountDao, executor);
         this.businessPaymentDao = new BusinessPaymentDao(osgiKillbillDataSource);
         bacFactory = new BusinessAccountFactory();
         binFactory = new BusinessInvoiceFactory(executor);
@@ -98,11 +98,10 @@ public class BusinessInvoiceAndPaymentDao extends BusinessAnalyticsDaoBase {
         logger.debug("Finished rebuild of Analytics invoices and payments for account {}", businessContextFactory.getAccountId());
     }
 
-    @VisibleForTesting
-    void createBusinessPojos(final BusinessContextFactory businessContextFactory,
-                             final Map<UUID, BusinessInvoiceModelDao> invoices,
-                             final Multimap<UUID, BusinessInvoiceItemBaseModelDao> invoiceItems,
-                             final Multimap<UUID, BusinessPaymentBaseModelDao> invoicePayments) throws AnalyticsRefreshException {
+    private void createBusinessPojos(final BusinessContextFactory businessContextFactory,
+                                     final Map<UUID, BusinessInvoiceModelDao> invoices,
+                                     final Multimap<UUID, BusinessInvoiceItemBaseModelDao> invoiceItems,
+                                     final Multimap<UUID, BusinessPaymentBaseModelDao> invoicePayments) throws AnalyticsRefreshException {
         // Recompute all invoices and invoice items
         final Map<BusinessInvoiceModelDao, Collection<BusinessInvoiceItemBaseModelDao>> businessInvoices = binFactory.createBusinessInvoicesAndInvoiceItems(businessContextFactory);
 

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessAccountFactory.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessAccountFactory.java
@@ -42,6 +42,7 @@ import com.google.common.collect.Iterables;
 
 public class BusinessAccountFactory {
 
+    // Always needs to be refreshed (depends on bundles, invoices and payments)
     public BusinessAccountModelDao createBusinessAccount(final BusinessContextFactory businessContextFactory) throws AnalyticsRefreshException {
         final Account account = businessContextFactory.getAccount();
         final Account parentAccount = businessContextFactory.getParentAccount();

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessFactoryBase.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessFactoryBase.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -39,6 +39,7 @@ import org.killbill.billing.entitlement.api.SubscriptionApi;
 import org.killbill.billing.entitlement.api.SubscriptionApiException;
 import org.killbill.billing.entitlement.api.SubscriptionBundle;
 import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.InvoiceApiException;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoicePayment;
 import org.killbill.billing.invoice.api.InvoiceUserApi;
@@ -203,7 +204,7 @@ public abstract class BusinessFactoryBase {
         try {
             return subscriptionApi.getSubscriptionBundlesForAccountId(accountId, context);
         } catch (final SubscriptionApiException e) {
-            logger.warn("Error retrieving bundles for account id {}",  accountId, e);
+            logger.warn("Error retrieving bundles for account id {}", accountId, e);
             throw new AnalyticsRefreshException(e);
         }
     }
@@ -218,7 +219,7 @@ public abstract class BusinessFactoryBase {
             }
             return bundles.get(bundles.size() - 1);
         } catch (final SubscriptionApiException e) {
-            logger.warn("Error retrieving bundles for bundle external key {}",  bundleExternalKey, e);
+            logger.warn("Error retrieving bundles for bundle external key {}", bundleExternalKey, e);
             throw new AnalyticsRefreshException(e);
         }
     }
@@ -316,6 +317,26 @@ public abstract class BusinessFactoryBase {
         return recordIdUserApi.getRecordId(invoiceItemId, ObjectType.INVOICE_ITEM, context);
     }
 
+    protected Invoice getInvoice(final UUID invoiceId, final TenantContext context) throws AnalyticsRefreshException {
+        final InvoiceUserApi invoiceUserApi = getInvoiceUserApi();
+        try {
+            return invoiceUserApi.getInvoice(invoiceId, context);
+        } catch (final InvoiceApiException e) {
+            logger.warn("Unable to retrieve invoice for {}", invoiceId, e);
+            return null;
+        }
+    }
+
+    protected Invoice getInvoiceByInvoiceItemId(final UUID invoiceItemId, final TenantContext context) throws AnalyticsRefreshException {
+        final InvoiceUserApi invoiceUserApi = getInvoiceUserApi();
+        try {
+            return invoiceUserApi.getInvoiceByInvoiceItem(invoiceItemId, context);
+        } catch (final InvoiceApiException e) {
+            logger.warn("Unable to retrieve invoice for invoice item {}", invoiceItemId, e);
+            return null;
+        }
+    }
+
     protected Collection<Invoice> getInvoicesByAccountId(final UUID accountId, final CallContext context) throws AnalyticsRefreshException {
         final InvoiceUserApi invoiceUserApi = getInvoiceUserApi();
         return invoiceUserApi.getInvoicesByAccount(accountId, false, false, context);
@@ -331,7 +352,7 @@ public abstract class BusinessFactoryBase {
             // Find the catalog when the invoice item was created (same logic as InvoiceItemFactory)
             return catalog.findPlan(invoiceItem.getPlanName(), invoiceItem.getCreatedDate());
         } catch (final CatalogApiException e) {
-            logger.warn("Unable to retrieve plan for invoice item {}",  invoiceItem.getId(), e);
+            logger.warn("Unable to retrieve plan for invoice item {}", invoiceItem.getId(), e);
             return null;
         }
     }
@@ -346,7 +367,7 @@ public abstract class BusinessFactoryBase {
         try {
             return plan.findPhase(invoiceItem.getPhaseName());
         } catch (final CatalogApiException e) {
-            logger.warn("Unable to retrieve phase for invoice item {}",  invoiceItem.getId(), e);
+            logger.warn("Unable to retrieve phase for invoice item {}", invoiceItem.getId(), e);
             return null;
         }
     }
@@ -429,7 +450,7 @@ public abstract class BusinessFactoryBase {
             }
         }
 
-        logger.warn("Error retrieving payments for account id {}",  accountId, error);
+        logger.warn("Error retrieving payments for account id {}", accountId, error);
         throw new AnalyticsRefreshException(error);
     }
 
@@ -461,7 +482,7 @@ public abstract class BusinessFactoryBase {
             }
         }
 
-        logger.warn("Error retrieving payment methods for account id {}",  accountId, error);
+        logger.warn("Error retrieving payment methods for account id {}", accountId, error);
         throw new AnalyticsRefreshException(error);
     }
 

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessInvoiceFactory.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessInvoiceFactory.java
@@ -74,10 +74,113 @@ public class BusinessInvoiceFactory {
     }
 
     /**
+     * Create current business invoice and invoice items.
+     *
+     * @return business invoice and associated invoice items to create
+     */
+    public Map<BusinessInvoiceModelDao, Collection<BusinessInvoiceItemBaseModelDao>> createBusinessInvoiceAndInvoiceItems(final UUID invoiceId,
+                                                                                                                          final BusinessContextFactory businessContextFactory) throws AnalyticsRefreshException {
+        // Pre-fetch these, to avoid contention on BusinessContextFactory
+        final Account account = businessContextFactory.getAccount();
+        final Long accountRecordId = businessContextFactory.getAccountRecordId();
+        final Long tenantRecordId = businessContextFactory.getTenantRecordId();
+        final ReportGroup reportGroup = businessContextFactory.getReportGroup();
+        final CurrencyConverter currencyConverter = businessContextFactory.getCurrencyConverter();
+
+        // Lookup the invoice
+        final Invoice invoice = businessContextFactory.getInvoice(invoiceId);
+
+        // Lookup all SubscriptionBundle for that account (this avoids expensive lookups for each item)
+        final Iterable<SubscriptionBundle> bundlesForAccount = businessContextFactory.getAccountBundles();
+        final Map<UUID, SubscriptionBundle> bundles = new LinkedHashMap<UUID, SubscriptionBundle>();
+        for (final SubscriptionBundle bundle : bundlesForAccount) {
+            bundles.put(bundle.getId(), bundle);
+        }
+
+        final Iterable<Tag> tags = businessContextFactory.getAccountTags();
+        final Set<UUID> writtenOffInvoices = new HashSet<UUID>();
+        for (final Tag cur : tags) {
+            if (cur.getTagDefinitionId().equals(ControlTagType.WRITTEN_OFF.getId())) {
+                writtenOffInvoices.add(cur.getObjectId());
+            }
+        }
+
+        // Create the business invoice items
+        final Multimap<UUID, BusinessInvoiceItemBaseModelDao> businessInvoiceItemsForInvoiceId = ArrayListMultimap.<UUID, BusinessInvoiceItemBaseModelDao>create();
+        for (final InvoiceItem invoiceItem : invoice.getInvoiceItems()) {
+            final AuditLog creationAuditLog = invoiceItem.getId() != null ? businessContextFactory.getInvoiceItemCreationAuditLog(invoiceItem.getId()) : null;
+            final boolean isWrittenOff = writtenOffInvoices.contains(invoiceItem.getInvoiceId());
+
+            final Collection<InvoiceItem> otherInvoiceItems = Collections2.filter(invoice.getInvoiceItems(),
+                                                                                  new Predicate<InvoiceItem>() {
+                                                                                      @Override
+                                                                                      public boolean apply(final InvoiceItem input) {
+                                                                                          return !input.getId().equals(invoiceItem.getId());
+                                                                                      }
+                                                                                  }
+                                                                                 );
+            InvoiceItem linkedInvoiceItem = null;
+            if (invoiceItem.getLinkedItemId() != null) {
+                // Try to find the linked item on that invoice first
+                linkedInvoiceItem = Iterables.tryFind(invoice.getInvoiceItems(),
+                                                      new Predicate<InvoiceItem>() {
+                                                          @Override
+                                                          public boolean apply(final InvoiceItem input) {
+                                                              return input.getId().equals(invoiceItem.getLinkedItemId());
+                                                          }
+                                                      })
+                                             .orNull();
+                if (linkedInvoiceItem == null) {
+                    // We need to go back to the database
+                    final Invoice linkedInvoice = businessContextFactory.getInvoiceByInvoiceItemId(invoiceItem.getLinkedItemId());
+                    for (final InvoiceItem invoiceItemOnLinkedInvoice : linkedInvoice.getInvoiceItems()) {
+                        if (invoiceItem.getLinkedItemId().equals(invoiceItemOnLinkedInvoice.getId())) {
+                            linkedInvoiceItem = invoiceItemOnLinkedInvoice;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            final BusinessInvoiceItemBaseModelDao businessInvoiceItemModelDao = createBusinessInvoiceItem(businessContextFactory,
+                                                                                                          account,
+                                                                                                          invoice,
+                                                                                                          invoiceItem,
+                                                                                                          otherInvoiceItems,
+                                                                                                          linkedInvoiceItem,
+                                                                                                          isWrittenOff,
+                                                                                                          bundles,
+                                                                                                          currencyConverter,
+                                                                                                          creationAuditLog,
+                                                                                                          accountRecordId,
+                                                                                                          tenantRecordId,
+                                                                                                          reportGroup);
+            if (businessInvoiceItemModelDao != null) {
+                businessInvoiceItemsForInvoiceId.get(businessInvoiceItemModelDao.getInvoiceId()).add(businessInvoiceItemModelDao);
+            }
+        }
+
+        // Now, create the business invoice
+        final Map<BusinessInvoiceModelDao, Collection<BusinessInvoiceItemBaseModelDao>> businessRecords = new HashMap<BusinessInvoiceModelDao, Collection<BusinessInvoiceItemBaseModelDao>>();
+        createBusinessInvoice(businessRecords,
+                              businessContextFactory,
+                              invoice,
+                              businessInvoiceItemsForInvoiceId,
+                              writtenOffInvoices,
+                              account,
+                              currencyConverter,
+                              accountRecordId,
+                              tenantRecordId,
+                              reportGroup);
+
+        return businessRecords;
+    }
+
+    /**
      * Create current business invoices and invoice items.
      *
      * @return all business invoice and invoice items to create
-     * @throws org.killbill.billing.plugin.analytics.AnalyticsRefreshException
+     * @throws AnalyticsRefreshException
      */
     public Map<BusinessInvoiceModelDao, Collection<BusinessInvoiceItemBaseModelDao>> createBusinessInvoicesAndInvoiceItems(final BusinessContextFactory businessContextFactory) throws AnalyticsRefreshException {
         // Pre-fetch these, to avoid contention on BusinessContextFactory
@@ -157,35 +260,57 @@ public class BusinessInvoiceFactory {
         // Now, create the business invoices
         final Map<BusinessInvoiceModelDao, Collection<BusinessInvoiceItemBaseModelDao>> businessRecords = new HashMap<BusinessInvoiceModelDao, Collection<BusinessInvoiceItemBaseModelDao>>();
         for (final Invoice invoice : invoices) {
-            final Collection<BusinessInvoiceItemBaseModelDao> businessInvoiceItems = businessInvoiceItemsForInvoiceId.get(invoice.getId());
-            if (businessInvoiceItems == null) {
-                continue;
-            }
-
-            final boolean isWrittenOff = writtenOffInvoices.contains(invoice.getId());
-
-            final Long invoiceRecordId = businessContextFactory.getInvoiceRecordId(invoice.getId());
-            final AuditLog creationAuditLog = businessContextFactory.getInvoiceCreationAuditLog(invoice.getId());
-
-            final BusinessInvoiceModelDao businessInvoice = new BusinessInvoiceModelDao(account,
-                                                                                        accountRecordId,
-                                                                                        invoice,
-                                                                                        isWrittenOff,
-                                                                                        invoiceRecordId,
-                                                                                        currencyConverter,
-                                                                                        creationAuditLog,
-                                                                                        tenantRecordId,
-                                                                                        reportGroup);
-
-            businessRecords.put(businessInvoice, businessInvoiceItems);
+            createBusinessInvoice(businessRecords,
+                                  businessContextFactory,
+                                  invoice,
+                                  businessInvoiceItemsForInvoiceId,
+                                  writtenOffInvoices,
+                                  account,
+                                  currencyConverter,
+                                  accountRecordId,
+                                  tenantRecordId,
+                                  reportGroup);
         }
 
         return businessRecords;
     }
 
+    private void createBusinessInvoice(final Map<BusinessInvoiceModelDao, Collection<BusinessInvoiceItemBaseModelDao>> businessRecords,
+                                       final BusinessContextFactory businessContextFactory,
+                                       final Invoice invoice,
+                                       final Multimap<UUID, BusinessInvoiceItemBaseModelDao> businessInvoiceItemsForInvoiceId,
+                                       final Collection<UUID> writtenOffInvoices,
+                                       final Account account,
+                                       final CurrencyConverter currencyConverter,
+                                       final Long accountRecordId,
+                                       final Long tenantRecordId,
+                                       final ReportGroup reportGroup) throws AnalyticsRefreshException {
+        final Collection<BusinessInvoiceItemBaseModelDao> businessInvoiceItems = businessInvoiceItemsForInvoiceId.get(invoice.getId());
+        if (businessInvoiceItems == null) {
+            return;
+        }
+
+        final boolean isWrittenOff = writtenOffInvoices.contains(invoice.getId());
+
+        final Long invoiceRecordId = businessContextFactory.getInvoiceRecordId(invoice.getId());
+        final AuditLog creationAuditLog = businessContextFactory.getInvoiceCreationAuditLog(invoice.getId());
+
+        final BusinessInvoiceModelDao businessInvoice = new BusinessInvoiceModelDao(account,
+                                                                                    accountRecordId,
+                                                                                    invoice,
+                                                                                    isWrittenOff,
+                                                                                    invoiceRecordId,
+                                                                                    currencyConverter,
+                                                                                    creationAuditLog,
+                                                                                    tenantRecordId,
+                                                                                    reportGroup);
+
+        businessRecords.put(businessInvoice, businessInvoiceItems);
+    }
+
     private BusinessInvoiceItemBaseModelDao createBusinessInvoiceItem(final BusinessContextFactory businessContextFactory,
                                                                       final InvoiceItem invoiceItem,
-                                                                      final Multimap<UUID, InvoiceItem> allInvoiceItems,
+                                                                      final Multimap<UUID, InvoiceItem> allInvoiceItemsAcrossAllInvoices,
                                                                       final Map<UUID, Invoice> invoiceIdToInvoiceMappings,
                                                                       final boolean isWrittenOff,
                                                                       final Account account,
@@ -196,24 +321,28 @@ public class BusinessInvoiceFactory {
                                                                       final Long tenantRecordId,
                                                                       final ReportGroup reportGroup) throws AnalyticsRefreshException {
         final Invoice invoice = invoiceIdToInvoiceMappings.get(invoiceItem.getInvoiceId());
-        final Collection<InvoiceItem> otherInvoiceItems = Collections2.filter(allInvoiceItems.values(),
+        final Collection<InvoiceItem> otherInvoiceItems = Collections2.filter(allInvoiceItemsAcrossAllInvoices.values(),
                                                                               new Predicate<InvoiceItem>() {
                                                                                   @Override
                                                                                   public boolean apply(final InvoiceItem input) {
-                                                                                      return input.getId() != null && !input.getId().equals(invoiceItem.getId());
-                                                                                  }
-
-                                                                                  @Override
-                                                                                  public boolean test(@Nullable final InvoiceItem input) {
-                                                                                      return apply(input);
+                                                                                      return !input.getId().equals(invoiceItem.getId()) &&
+                                                                                             input.getInvoiceId().equals(invoiceItem.getInvoiceId());
                                                                                   }
                                                                               }
                                                                              );
+        final InvoiceItem linkedInvoiceItem = Iterables.find(allInvoiceItemsAcrossAllInvoices.values(), new Predicate<InvoiceItem>() {
+            @Override
+            public boolean apply(final InvoiceItem input) {
+                return invoiceItem.getLinkedItemId() != null && invoiceItem.getLinkedItemId().equals(input.getId());
+
+            }
+        }, null);
         return createBusinessInvoiceItem(businessContextFactory,
                                          account,
                                          invoice,
                                          invoiceItem,
                                          otherInvoiceItems,
+                                         linkedInvoiceItem,
                                          isWrittenOff,
                                          bundles,
                                          currencyConverter,
@@ -229,6 +358,8 @@ public class BusinessInvoiceFactory {
                                                               final Invoice invoice,
                                                               final InvoiceItem invoiceItem,
                                                               final Collection<InvoiceItem> otherInvoiceItems,
+                                                              // For convenience, populate empty columns using the linked item
+                                                              @Nullable final InvoiceItem linkedInvoiceItem,
                                                               final boolean isWrittenOff,
                                                               final Map<UUID, SubscriptionBundle> bundles,
                                                               final CurrencyConverter currencyConverter,
@@ -236,19 +367,6 @@ public class BusinessInvoiceFactory {
                                                               final Long accountRecordId,
                                                               final Long tenantRecordId,
                                                               @Nullable final ReportGroup reportGroup) throws AnalyticsRefreshException {
-        // For convenience, populate empty columns using the linked item
-        final InvoiceItem linkedInvoiceItem = Iterables.find(otherInvoiceItems, new Predicate<InvoiceItem>() {
-            @Override
-            public boolean apply(final InvoiceItem input) {
-                return invoiceItem.getLinkedItemId() != null && invoiceItem.getLinkedItemId().equals(input.getId());
-            }
-
-            @Override
-            public boolean test(@Nullable final InvoiceItem input) {
-                return apply(input);
-            }
-        }, null);
-
         SubscriptionBundle bundle = null;
         // Subscription and bundle could be null for e.g. credits or adjustments
         if (invoiceItem.getBundleId() != null) {

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/model/BusinessAccountModelDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/model/BusinessAccountModelDao.java
@@ -376,7 +376,6 @@ public class BusinessAccountModelDao extends BusinessModelDaoBase {
         return parentAccountExternalKey;
     }
 
-
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("BusinessAccountModelDao{");
@@ -521,7 +520,7 @@ public class BusinessAccountModelDao extends BusinessModelDaoBase {
         if (parentAccountId != null ? !parentAccountId.equals(that.parentAccountId) : that.parentAccountId != null) {
             return false;
         }
-        if(parentAccountName != null ? !parentAccountName.equals(that.parentAccountName) : that.parentAccountName != null) {
+        if (parentAccountName != null ? !parentAccountName.equals(that.parentAccountName) : that.parentAccountName != null) {
             return false;
         }
         if (paymentMethodId != null ? !paymentMethodId.equals(that.paymentMethodId) : that.paymentMethodId != null) {

--- a/src/main/java/org/killbill/billing/plugin/analytics/utils/BusinessInvoiceUtils.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/utils/BusinessInvoiceUtils.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import javax.annotation.Nullable;
 
 import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.api.InvoicePayment;
@@ -39,19 +40,7 @@ import com.google.common.collect.Iterables;
  */
 public class BusinessInvoiceUtils {
 
-    public static boolean isRevenueRecognizable(final InvoiceItem invoiceItem, final Collection<InvoiceItem> otherInvoiceItemsOnAllInvoices) {
-        final Collection<InvoiceItem> otherInvoiceItems = Collections2.filter(otherInvoiceItemsOnAllInvoices, new Predicate<InvoiceItem>() {
-            @Override
-            public boolean apply(final InvoiceItem input) {
-                return input.getInvoiceId().equals(invoiceItem.getInvoiceId());
-            }
-
-            @Override
-            public boolean test(@Nullable final InvoiceItem input) {
-                return apply(input);
-            }
-        });
-
+    public static boolean isRevenueRecognizable(final InvoiceItem invoiceItem, final Collection<InvoiceItem> otherInvoiceItems) {
         // All items are recognizable except user generated credit (CBA_ADJ and CREDIT_ADJ on their own invoice)
         return !(InvoiceItemType.CBA_ADJ.equals(invoiceItem.getInvoiceItemType()) &&
                  (otherInvoiceItems.size() == 1 &&
@@ -61,19 +50,7 @@ public class BusinessInvoiceUtils {
     }
 
     // Invoice adjustments
-    public static boolean isInvoiceAdjustmentItem(final InvoiceItem invoiceItem, final Collection<InvoiceItem> otherInvoiceItemsOnAllInvoices) {
-        final Collection<InvoiceItem> otherInvoiceItems = Collections2.filter(otherInvoiceItemsOnAllInvoices, new Predicate<InvoiceItem>() {
-            @Override
-            public boolean apply(final InvoiceItem input) {
-                return input.getInvoiceId().equals(invoiceItem.getInvoiceId());
-            }
-
-            @Override
-            public boolean test(@Nullable final InvoiceItem input) {
-                return apply(input);
-            }
-        });
-
+    public static boolean isInvoiceAdjustmentItem(final InvoiceItem invoiceItem, final Iterable<InvoiceItem> otherInvoiceItems) {
         // Invoice level credit, i.e. credit adj, but NOT on its on own invoice
         // Note: the negative credit adj items (internal generation of account level credits) doesn't figure in analytics
         return (InvoiceItemType.CREDIT_ADJ.equals(invoiceItem.getInvoiceItemType()) &&

--- a/src/main/resources/org/killbill/billing/plugin/analytics/dao/BusinessAnalyticsSqlDao.sql.stg
+++ b/src/main/resources/org/killbill/billing/plugin/analytics/dao/BusinessAnalyticsSqlDao.sql.stg
@@ -2238,12 +2238,16 @@ insert into analytics_transaction_fields (
 );
 >>
 
-CHECK_TENANT_AND_ACCOUNT(prefix) ::= <<
+CHECK_TENANT(prefix) ::= <<
 case
     when <prefix>tenant_record_id is null and :tenantRecordId is null then true
     when <prefix>tenant_record_id is null or  :tenantRecordId is null then false
     else <prefix>tenant_record_id = :tenantRecordId
 end
+>>
+
+CHECK_TENANT_AND_ACCOUNT(prefix) ::= <<
+<CHECK_TENANT(prefix)>
 and <prefix>account_record_id = :accountRecordId
 >>
 
@@ -2251,6 +2255,13 @@ SELECT_STAR_FROM_TABLE(table) ::= <<
 select *
 from <table> t
 where <CHECK_TENANT_AND_ACCOUNT("t.")>
+>>
+
+deleteByInvoiceId(tableName) ::= <<
+delete from <tableName>
+where <CHECK_TENANT("")>
+and invoice_id = :invoiceId
+;
 >>
 
 deleteByAccountRecordId(tableName) ::= <<

--- a/src/test/java/org/killbill/billing/plugin/analytics/AnalyticsTestSuiteNoDB.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/AnalyticsTestSuiteNoDB.java
@@ -20,6 +20,7 @@ package org.killbill.billing.plugin.analytics;
 import java.math.BigDecimal;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 
 import javax.annotation.Nullable;
 import javax.sql.DataSource;
@@ -31,6 +32,7 @@ import org.killbill.billing.ObjectType;
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.account.api.AccountUserApi;
 import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.CatalogUserApi;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.catalog.api.InternationalPrice;
 import org.killbill.billing.catalog.api.PhaseType;
@@ -40,6 +42,8 @@ import org.killbill.billing.catalog.api.PriceList;
 import org.killbill.billing.catalog.api.Product;
 import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.catalog.api.Recurring;
+import org.killbill.billing.catalog.api.VersionedCatalog;
+import org.killbill.billing.entitlement.api.Subscription;
 import org.killbill.billing.entitlement.api.SubscriptionApi;
 import org.killbill.billing.entitlement.api.SubscriptionBundle;
 import org.killbill.billing.entitlement.api.SubscriptionEvent;
@@ -49,11 +53,14 @@ import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.api.InvoicePayment;
 import org.killbill.billing.invoice.api.InvoicePaymentType;
+import org.killbill.billing.invoice.api.InvoiceUserApi;
 import org.killbill.billing.osgi.libs.killbill.OSGIConfigPropertiesService;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
+import org.killbill.billing.payment.api.InvoicePaymentApi;
 import org.killbill.billing.payment.api.Payment;
+import org.killbill.billing.payment.api.PaymentApi;
 import org.killbill.billing.payment.api.PaymentMethod;
 import org.killbill.billing.payment.api.PaymentMethodPlugin;
 import org.killbill.billing.payment.api.PaymentTransaction;
@@ -64,12 +71,14 @@ import org.killbill.billing.plugin.analytics.api.core.AnalyticsConfiguration;
 import org.killbill.billing.plugin.analytics.api.core.AnalyticsConfigurationHandler;
 import org.killbill.billing.plugin.analytics.dao.CurrencyConversionDao;
 import org.killbill.billing.plugin.analytics.dao.TestCallContext;
+import org.killbill.billing.plugin.analytics.dao.factory.BusinessContextFactory;
 import org.killbill.billing.plugin.analytics.dao.factory.PluginPropertiesManager;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessInvoiceItemBaseModelDao.BusinessInvoiceItemType;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessInvoiceItemBaseModelDao.ItemSource;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessModelDaoBase;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessModelDaoBase.ReportGroup;
 import org.killbill.billing.plugin.analytics.utils.CurrencyConverter;
+import org.killbill.billing.tenant.api.TenantUserApi;
 import org.killbill.billing.util.api.AuditLevel;
 import org.killbill.billing.util.api.AuditUserApi;
 import org.killbill.billing.util.api.CustomFieldUserApi;
@@ -86,7 +95,6 @@ import org.killbill.billing.util.tag.Tag;
 import org.killbill.billing.util.tag.TagDefinition;
 import org.killbill.clock.ClockMock;
 import org.killbill.notificationq.DefaultNotificationQueueService;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -137,6 +145,7 @@ public abstract class AnalyticsTestSuiteNoDB {
     protected SubscriptionEvent subscriptionTransition;
     protected Invoice invoice;
     protected InvoiceItem invoiceItem;
+    protected InvoiceItem linkedInvoiceItem;
     protected InvoicePayment invoicePayment;
     protected PaymentMethod paymentMethod;
     protected Payment payment;
@@ -155,6 +164,8 @@ public abstract class AnalyticsTestSuiteNoDB {
     protected OSGIKillbillAPI killbillAPI;
     protected OSGIKillbillDataSource killbillDataSource;
     protected OSGIConfigPropertiesService osgiConfigPropertiesService;
+    protected ExecutorService executor;
+    protected BusinessContextFactory businessContextFactory;
 
     protected void verifyBusinessEntityBase(final BusinessEntityBase businessEntityBase) {
         Assert.assertEquals(businessEntityBase.getCreatedBy(), auditLog.getUserName());
@@ -196,7 +207,24 @@ public abstract class AnalyticsTestSuiteNoDB {
                                             final BigDecimal amount,
                                             @Nullable final UUID linkedItemId) {
         final UUID invoiceItemId = UUID.randomUUID();
+        return createInvoiceItem(invoiceItemId,
+                                 invoiceId,
+                                 invoiceItemType,
+                                 subscriptionId,
+                                 startDate,
+                                 endDate,
+                                 amount,
+                                 linkedItemId);
+    }
 
+    protected InvoiceItem createInvoiceItem(final UUID invoiceItemId,
+                                            final UUID invoiceId,
+                                            final InvoiceItemType invoiceItemType,
+                                            final UUID subscriptionId,
+                                            final LocalDate startDate,
+                                            final LocalDate endDate,
+                                            final BigDecimal amount,
+                                            @Nullable final UUID linkedItemId) {
         final InvoiceItem invoiceItem = Mockito.mock(InvoiceItem.class);
         Mockito.when(invoiceItem.getId()).thenReturn(invoiceItemId);
         Mockito.when(invoiceItem.getInvoiceItemType()).thenReturn(invoiceItemType);
@@ -229,8 +257,6 @@ public abstract class AnalyticsTestSuiteNoDB {
                 return null;
             }
         }).when(logService).log(Mockito.anyInt(), Mockito.anyString());
-
-        analyticsConfigurationHandler = new AnalyticsConfigurationHandler(AnalyticsActivator.PLUGIN_NAME, killbillAPI, logService);
 
         Mockito.when(currencyConverter.getConvertedCurrency()).thenReturn("USD");
         Mockito.when(currencyConverter.getConvertedValue(Mockito.<BigDecimal>any(), Mockito.anyString(), Mockito.<LocalDate>any())).thenReturn(BigDecimal.TEN);
@@ -279,6 +305,12 @@ public abstract class AnalyticsTestSuiteNoDB {
         Mockito.when(bundle.getCreatedDate()).thenReturn(new DateTime(2016, 1, 22, 10, 56, 48, DateTimeZone.UTC));
         final UUID bundleId = bundle.getId();
 
+        final UUID subscriptionId = UUID.randomUUID();
+        final Subscription subscription = Mockito.mock(Subscription.class);
+        Mockito.when(subscription.getBaseEntitlementId()).thenReturn(subscriptionId);
+        Mockito.when(subscription.getId()).thenReturn(subscriptionId);
+        Mockito.when(bundle.getSubscriptions()).thenReturn(ImmutableList.<Subscription>of(subscription));
+
         final Product product = Mockito.mock(Product.class);
         Mockito.when(product.getName()).thenReturn(UUID.randomUUID().toString());
         Mockito.when(product.getCategory()).thenReturn(ProductCategory.STANDALONE);
@@ -292,7 +324,7 @@ public abstract class AnalyticsTestSuiteNoDB {
         final String planName = plan.getName();
 
         phase = Mockito.mock(PlanPhase.class);
-        Recurring recurring = Mockito.mock(Recurring.class);
+        final Recurring recurring = Mockito.mock(Recurring.class);
         Mockito.when(recurring.getBillingPeriod()).thenReturn(BillingPeriod.QUARTERLY);
         Mockito.when(phase.getRecurring()).thenReturn(recurring);
         Mockito.when(phase.getName()).thenReturn(UUID.randomUUID().toString());
@@ -307,7 +339,7 @@ public abstract class AnalyticsTestSuiteNoDB {
         Mockito.when(priceList.getName()).thenReturn(UUID.randomUUID().toString());
 
         subscriptionTransition = Mockito.mock(SubscriptionEvent.class);
-        Mockito.when(subscriptionTransition.getEntitlementId()).thenReturn(UUID.randomUUID());
+        Mockito.when(subscriptionTransition.getEntitlementId()).thenReturn(subscriptionId);
         Mockito.when(subscriptionTransition.getServiceName()).thenReturn(serviceName);
         Mockito.when(subscriptionTransition.getServiceStateName()).thenReturn(stateName);
         Mockito.when(subscriptionTransition.getNextPlan()).thenReturn(plan);
@@ -317,7 +349,6 @@ public abstract class AnalyticsTestSuiteNoDB {
         Mockito.when(subscriptionTransition.getEffectiveDate()).thenReturn(new LocalDate(2011, 2, 3));
         Mockito.when(subscriptionTransition.getSubscriptionEventType()).thenReturn(SubscriptionEventType.START_ENTITLEMENT);
         Mockito.when(subscriptionTransition.getId()).thenReturn(UUID.randomUUID());
-        final UUID subscriptionId = subscriptionTransition.getEntitlementId();
         final UUID nextEventId = subscriptionTransition.getId();
 
         invoiceItem = Mockito.mock(InvoiceItem.class);
@@ -339,11 +370,21 @@ public abstract class AnalyticsTestSuiteNoDB {
         Mockito.when(invoiceItem.getCreatedDate()).thenReturn(new DateTime(2016, 1, 22, 10, 56, 51, DateTimeZone.UTC));
         final UUID invoiceItemId = invoiceItem.getId();
 
-        final UUID invoiceId = UUID.randomUUID();
+        linkedInvoiceItem = createInvoiceItem(invoiceItem.getLinkedItemId(),
+                                              invoiceItem.getInvoiceId(),
+                                              InvoiceItemType.TAX,
+                                              invoiceItem.getSubscriptionId(),
+                                              null,
+                                              null,
+                                              BigDecimal.ONE,
+                                              null);
+
+        final UUID invoiceId = invoiceItem.getInvoiceId();
+        final UUID paymentId = UUID.randomUUID();
 
         invoicePayment = Mockito.mock(InvoicePayment.class);
         Mockito.when(invoicePayment.getId()).thenReturn(UUID.randomUUID());
-        Mockito.when(invoicePayment.getPaymentId()).thenReturn(UUID.randomUUID());
+        Mockito.when(invoicePayment.getPaymentId()).thenReturn(paymentId);
         Mockito.when(invoicePayment.getType()).thenReturn(InvoicePaymentType.ATTEMPT);
         Mockito.when(invoicePayment.getInvoiceId()).thenReturn(invoiceId);
         Mockito.when(invoicePayment.getPaymentDate()).thenReturn(new DateTime(2003, 4, 12, 3, 34, 52, DateTimeZone.UTC));
@@ -356,8 +397,8 @@ public abstract class AnalyticsTestSuiteNoDB {
 
         invoice = Mockito.mock(Invoice.class);
         Mockito.when(invoice.getId()).thenReturn(invoiceId);
-        Mockito.when(invoice.getInvoiceItems()).thenReturn(ImmutableList.<InvoiceItem>of(invoiceItem));
-        Mockito.when(invoice.getNumberOfItems()).thenReturn(1);
+        Mockito.when(invoice.getInvoiceItems()).thenReturn(ImmutableList.<InvoiceItem>of(invoiceItem, linkedInvoiceItem));
+        Mockito.when(invoice.getNumberOfItems()).thenReturn(2);
         Mockito.when(invoice.getPayments()).thenReturn(ImmutableList.<InvoicePayment>of(invoicePayment));
         Mockito.when(invoice.getNumberOfPayments()).thenReturn(1);
         Mockito.when(invoice.getAccountId()).thenReturn(accountId);
@@ -370,7 +411,7 @@ public abstract class AnalyticsTestSuiteNoDB {
         Mockito.when(invoice.getChargedAmount()).thenReturn(new BigDecimal("100293"));
         Mockito.when(invoice.getCreditedAmount()).thenReturn(new BigDecimal("283"));
         Mockito.when(invoice.getRefundedAmount()).thenReturn(new BigDecimal("384"));
-        Mockito.when(invoice.getBalance()).thenReturn(new BigDecimal("12000"));
+        Mockito.when(invoice.getBalance()).thenReturn(new BigDecimal("12001"));
         Mockito.when(invoice.isMigrationInvoice()).thenReturn(false);
         Mockito.when(invoice.getCreatedDate()).thenReturn(INVOICE_CREATED_DATE);
 
@@ -415,7 +456,7 @@ public abstract class AnalyticsTestSuiteNoDB {
         Mockito.when(refundTransaction.getTransactionStatus()).thenReturn(TransactionStatus.PENDING);
 
         payment = Mockito.mock(Payment.class);
-        Mockito.when(payment.getId()).thenReturn(UUID.randomUUID());
+        Mockito.when(payment.getId()).thenReturn(paymentId);
         Mockito.when(payment.getAccountId()).thenReturn(accountId);
         Mockito.when(payment.getPaymentMethodId()).thenReturn(paymentMethodId);
         Mockito.when(payment.getPaymentNumber()).thenReturn(1);
@@ -512,15 +553,69 @@ public abstract class AnalyticsTestSuiteNoDB {
         Mockito.when(auditUserApi.getAuditLogs(Mockito.<UUID>any(), Mockito.<ObjectType>any(), Mockito.<AuditLevel>any(), Mockito.<TenantContext>any())).thenReturn(ImmutableList.<AuditLog>of());
 
         final SubscriptionApi subscriptionApi = Mockito.mock(SubscriptionApi.class);
-        Mockito.when(subscriptionApi.getSubscriptionBundlesForAccountId(Mockito.<UUID>any(), Mockito.<TenantContext>any())).thenReturn(ImmutableList.<SubscriptionBundle>of());
+        Mockito.when(subscriptionApi.getSubscriptionBundlesForAccountId(Mockito.<UUID>any(), Mockito.<TenantContext>any())).thenReturn(ImmutableList.<SubscriptionBundle>of(bundle));
+        Mockito.when(subscriptionApi.getSubscriptionBundlesForExternalKey(Mockito.<String>any(), Mockito.<TenantContext>any())).thenReturn(ImmutableList.<SubscriptionBundle>of(bundle));
+
+        final InvoiceUserApi invoiceApi = Mockito.mock(InvoiceUserApi.class);
+        Mockito.when(invoiceApi.getInvoicesByAccount(Mockito.eq(account.getId()),
+                                                     Mockito.anyBoolean(),
+                                                     Mockito.anyBoolean(),
+                                                     Mockito.any(TenantContext.class)))
+               .thenReturn(ImmutableList.of(invoice));
+        Mockito.when(invoiceApi.getInvoiceByInvoiceItem(Mockito.eq(invoiceItem.getId()),
+                                                        Mockito.any(TenantContext.class)))
+               .thenReturn(invoice);
+        Mockito.when(invoiceApi.getInvoiceByInvoiceItem(Mockito.eq(linkedInvoiceItem.getId()),
+                                                        Mockito.any(TenantContext.class)))
+               .thenReturn(invoice);
+
+        final PaymentApi paymentApi = Mockito.mock(PaymentApi.class);
+        //noinspection unchecked
+        Mockito.when(paymentApi.getAccountPayments(Mockito.eq(account.getId()),
+                                                   Mockito.anyBoolean(),
+                                                   Mockito.anyBoolean(),
+                                                   Mockito.any(Iterable.class),
+                                                   Mockito.any(TenantContext.class)))
+               .thenReturn(ImmutableList.of(payment));
+        //noinspection unchecked
+        Mockito.when(paymentApi.getAccountPaymentMethods(Mockito.eq(account.getId()),
+                                                         Mockito.anyBoolean(),
+                                                         Mockito.anyBoolean(),
+                                                         Mockito.any(Iterable.class),
+                                                         Mockito.any(TenantContext.class)))
+               .thenReturn(ImmutableList.of(paymentMethod));
+
+        final InvoicePaymentApi invoicePaymentApi = Mockito.mock(InvoicePaymentApi.class);
+        Mockito.when(invoicePaymentApi.getInvoicePayments(Mockito.eq(payment.getId()),
+                                                          Mockito.any(TenantContext.class)))
+               .thenReturn(ImmutableList.<InvoicePayment>of(invoicePayment));
+
+        final CatalogUserApi catalogUserApi = Mockito.mock(CatalogUserApi.class);
+        final VersionedCatalog catalog = Mockito.mock(VersionedCatalog.class);
+        //noinspection unchecked
+        Mockito.when(catalogUserApi.getCatalog(Mockito.anyString(),
+                                               Mockito.any(),
+                                               Mockito.any(TenantContext.class)))
+               .thenReturn(catalog);
+        Mockito.when(catalog.findPlan(Mockito.eq(plan.getName()),
+                                      Mockito.any()))
+               .thenReturn(plan);
 
         Mockito.when(tagUserApi.getTagsForObject(Mockito.<UUID>any(), Mockito.<ObjectType>any(), Mockito.anyBoolean(), Mockito.<TenantContext>any())).thenReturn(ImmutableList.<Tag>of());
+
+        final TenantUserApi tenantUserApi = Mockito.mock(TenantUserApi.class);
+
         Mockito.when(killbillAPI.getAccountUserApi()).thenReturn(accountUserApi);
         Mockito.when(killbillAPI.getSubscriptionApi()).thenReturn(subscriptionApi);
+        Mockito.when(killbillAPI.getInvoiceUserApi()).thenReturn(invoiceApi);
+        Mockito.when(killbillAPI.getPaymentApi()).thenReturn(paymentApi);
+        Mockito.when(killbillAPI.getInvoicePaymentApi()).thenReturn(invoicePaymentApi);
         Mockito.when(killbillAPI.getRecordIdApi()).thenReturn(recordIdApi);
         Mockito.when(killbillAPI.getTagUserApi()).thenReturn(tagUserApi);
         Mockito.when(killbillAPI.getCustomFieldUserApi()).thenReturn(customFieldUserApi);
         Mockito.when(killbillAPI.getAuditUserApi()).thenReturn(auditUserApi);
+        Mockito.when(killbillAPI.getCatalogUserApi()).thenReturn(catalogUserApi);
+        Mockito.when(killbillAPI.getTenantUserApi()).thenReturn(tenantUserApi);
 
         killbillDataSource = Mockito.mock(OSGIKillbillDataSource.class);
         final DataSource dataSource = Mockito.mock(DataSource.class);
@@ -535,9 +630,22 @@ public abstract class AnalyticsTestSuiteNoDB {
         Mockito.when(osgiConfigPropertiesService.getProperties()).thenReturn(properties);
         Mockito.when(osgiConfigPropertiesService.getString(Mockito.<String>any())).thenAnswer(new Answer<Object>() {
             @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
+            public Object answer(final InvocationOnMock invocation) {
                 return properties.getProperty((String) invocation.getArguments()[0]);
             }
         });
+
+        executor = BusinessExecutor.newCachedThreadPool(osgiConfigPropertiesService);
+
+        analyticsConfigurationHandler = new AnalyticsConfigurationHandler(AnalyticsActivator.PLUGIN_NAME, killbillAPI, logService);
+        analyticsConfigurationHandler.setDefaultConfigurable(new AnalyticsConfiguration(new Properties()));
+
+        businessContextFactory = new BusinessContextFactory(account.getId(),
+                                                            callContext,
+                                                            currencyConversionDao,
+                                                            killbillAPI,
+                                                            osgiConfigPropertiesService,
+                                                            clock,
+                                                            analyticsConfigurationHandler);
     }
 }

--- a/src/test/java/org/killbill/billing/plugin/analytics/AnalyticsTestSuiteWithEmbeddedDB.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/AnalyticsTestSuiteWithEmbeddedDB.java
@@ -24,6 +24,7 @@ import javax.sql.DataSource;
 
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
 import org.killbill.billing.platform.test.PlatformDBTestingHelper;
+import org.killbill.billing.plugin.analytics.api.user.AnalyticsUserApi;
 import org.killbill.billing.plugin.analytics.dao.BusinessAnalyticsSqlDao;
 import org.killbill.billing.plugin.analytics.dao.BusinessDBIProvider;
 import org.killbill.billing.plugin.analytics.dao.model.CurrencyConversionModelDao;
@@ -62,6 +63,7 @@ public abstract class AnalyticsTestSuiteWithEmbeddedDB extends AnalyticsTestSuit
     protected DBI dbi;
     protected BusinessAnalyticsSqlDao analyticsSqlDao;
     protected DefaultNotificationQueueService notificationQueueService;
+    protected AnalyticsUserApi analyticsUserApi;
 
     @BeforeSuite(groups = "slow")
     public void setUpSuite(final ITestContext context) throws Exception {
@@ -88,6 +90,13 @@ public abstract class AnalyticsTestSuiteWithEmbeddedDB extends AnalyticsTestSuit
         final NotificationQueueConfig config = new ConfigurationObjectFactory(osgiConfigPropertiesService.getProperties()).buildWithReplacements(NotificationQueueConfig.class,
                                                                                                                                                  ImmutableMap.<String, String>of("instanceName", "analytics"));
         notificationQueueService = new DefaultNotificationQueueService(dbi, clock, config, new MetricRegistry());
+
+        analyticsUserApi = new AnalyticsUserApi(killbillAPI,
+                                                killbillDataSource,
+                                                osgiConfigPropertiesService,
+                                                executor,
+                                                clock,
+                                                analyticsConfigurationHandler);
     }
 
     @AfterSuite(groups = "slow")

--- a/src/test/java/org/killbill/billing/plugin/analytics/TestAnalyticsNotificationQueue.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/TestAnalyticsNotificationQueue.java
@@ -71,7 +71,7 @@ public class TestAnalyticsNotificationQueue extends AnalyticsTestSuiteWithEmbedd
 
         // Send the first event
         final ExtBusEvent firstEvent = createExtBusEvent();
-        Mockito.when(firstEvent.getEventType()).thenReturn(ExtBusEventType.INVOICE_CREATION);
+        Mockito.when(firstEvent.getEventType()).thenReturn(ExtBusEventType.PAYMENT_FAILED);
         analyticsListener.handleKillbillEvent(firstEvent);
 
         // Verify the size of the queue
@@ -93,7 +93,7 @@ public class TestAnalyticsNotificationQueue extends AnalyticsTestSuiteWithEmbedd
 
         // Now, send a different event type, but triggering the same refresh type as the first event
         final ExtBusEvent thirdEvent = createExtBusEvent();
-        Mockito.when(thirdEvent.getEventType()).thenReturn(ExtBusEventType.PAYMENT_FAILED);
+        Mockito.when(thirdEvent.getEventType()).thenReturn(ExtBusEventType.PAYMENT_SUCCESS);
         analyticsListener.handleKillbillEvent(thirdEvent);
 
         // Verify the size of the queue

--- a/src/test/java/org/killbill/billing/plugin/analytics/dao/TestBusinessInvoiceDao.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/dao/TestBusinessInvoiceDao.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.analytics.dao;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import org.joda.time.LocalDate;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.InvoiceItem;
+import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.plugin.analytics.AnalyticsRefreshException;
+import org.killbill.billing.plugin.analytics.AnalyticsTestSuiteWithEmbeddedDB;
+import org.killbill.billing.plugin.analytics.api.BusinessInvoice;
+import org.killbill.billing.plugin.analytics.api.BusinessSnapshot;
+import org.killbill.billing.plugin.analytics.dao.factory.BusinessContextFactory;
+import org.killbill.billing.plugin.analytics.dao.model.BusinessInvoiceItemModelDao;
+import org.killbill.billing.plugin.analytics.dao.model.BusinessInvoiceModelDao;
+import org.killbill.billing.util.callcontext.TenantContext;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class TestBusinessInvoiceDao extends AnalyticsTestSuiteWithEmbeddedDB {
+
+    private BusinessInvoiceDao businessInvoiceDao;
+    private BusinessInvoiceAndPaymentDao businessInvoiceAndPaymentDao;
+
+    @BeforeMethod(groups = "slow")
+    public void set2Up() {
+        final BusinessAccountDao businessAccountDao = new BusinessAccountDao(killbillDataSource);
+        businessInvoiceDao = new BusinessInvoiceDao(killbillDataSource,
+                                                    businessAccountDao,
+                                                    executor);
+        businessInvoiceAndPaymentDao = new BusinessInvoiceAndPaymentDao(killbillDataSource,
+                                                                        businessAccountDao,
+                                                                        executor);
+    }
+
+    @Test(groups = "slow")
+    public void testUpdate() throws AnalyticsRefreshException {
+        final BusinessSnapshot businessSnapshot1 = analyticsUserApi.getBusinessSnapshot(account.getId(), callContext);
+        Assert.assertNull(businessSnapshot1.getBusinessAccount());
+        Assert.assertEquals(businessSnapshot1.getBusinessInvoices().size(), 0);
+
+        // Refresh that one invoice
+        businessInvoiceDao.update(invoice.getId(), businessContextFactory);
+
+        final BusinessSnapshot businessSnapshot2 = analyticsUserApi.getBusinessSnapshot(account.getId(), callContext);
+        Assert.assertEquals(businessSnapshot2.getBusinessAccount().getAccountId(), account.getId());
+        Assert.assertEquals(businessSnapshot2.getBusinessAccount().getLastInvoiceId(), invoice.getId());
+        Assert.assertEquals(businessSnapshot2.getBusinessInvoices().size(), 1);
+        final BusinessInvoice businessInvoice21 = businessSnapshot2.getBusinessInvoices().iterator().next();
+        Assert.assertEquals(businessInvoice21.getInvoiceItems().size(), 2);
+        Assert.assertTrue("EXTERNAL_CHARGE".equals(businessInvoice21.getInvoiceItems().get(0).getItemType()) && "TAX".equals(businessInvoice21.getInvoiceItems().get(1).getItemType()) ||
+                          "EXTERNAL_CHARGE".equals(businessInvoice21.getInvoiceItems().get(1).getItemType()) && "TAX".equals(businessInvoice21.getInvoiceItems().get(0).getItemType()));
+
+        final Long bacRecordId1 = analyticsSqlDao.getAccountByAccountRecordId(accountRecordId, tenantRecordId, callContext).getRecordId();
+        final Long binRecordId1 = analyticsSqlDao.getInvoicesByAccountRecordId(accountRecordId, tenantRecordId, callContext).get(0).getRecordId();
+        final List<BusinessInvoiceItemModelDao> invoiceItemsModelDao1 = analyticsSqlDao.getInvoiceItemsByAccountRecordId(accountRecordId, tenantRecordId, callContext);
+        final Long biiRecordId11 = invoiceItemsModelDao1.get(0).getRecordId();
+        final Long biiRecordId12 = invoiceItemsModelDao1.get(1).getRecordId();
+
+        // Full invoices and payments refresh
+        businessInvoiceAndPaymentDao.update(businessContextFactory);
+
+        // Verify the state is the same
+        final BusinessSnapshot businessSnapshot3 = analyticsUserApi.getBusinessSnapshot(account.getId(), callContext);
+        Assert.assertEquals(businessSnapshot3.getBusinessAccount(), businessSnapshot2.getBusinessAccount());
+        Assert.assertEquals(businessSnapshot3.getBusinessInvoices().size(), 1);
+        Assert.assertEqualsNoOrder(businessSnapshot3.getBusinessInvoices().iterator().next().getInvoiceItems().toArray(), businessInvoice21.getInvoiceItems().toArray());
+
+        // Verify the rows have been recreated
+        final Long bacRecordId2 = analyticsSqlDao.getAccountByAccountRecordId(accountRecordId, tenantRecordId, callContext).getRecordId();
+        final Long binRecordId2 = analyticsSqlDao.getInvoicesByAccountRecordId(accountRecordId, tenantRecordId, callContext).get(0).getRecordId();
+        final List<BusinessInvoiceItemModelDao> invoiceItemsModelDao2 = analyticsSqlDao.getInvoiceItemsByAccountRecordId(accountRecordId, tenantRecordId, callContext);
+        final Long biiRecordId21 = invoiceItemsModelDao2.get(0).getRecordId();
+        final Long biiRecordId22 = invoiceItemsModelDao2.get(1).getRecordId();
+        Assert.assertTrue(bacRecordId2 > bacRecordId1);
+        Assert.assertTrue(binRecordId2 > binRecordId1);
+        Assert.assertTrue(biiRecordId21 > Math.max(biiRecordId11, biiRecordId12));
+        Assert.assertTrue(biiRecordId22 > Math.max(biiRecordId11, biiRecordId12));
+
+        // Add a new invoice
+        final UUID invoiceId2 = UUID.randomUUID();
+        final InvoiceItem newInvoiceItem = createInvoiceItem(invoiceId2, InvoiceItemType.RECURRING);
+        final Invoice invoice2 = Mockito.mock(Invoice.class);
+        Mockito.when(invoice2.getId()).thenReturn(invoiceId2);
+        Mockito.when(invoice2.getInvoiceItems()).thenReturn(ImmutableList.<InvoiceItem>of(newInvoiceItem));
+        Mockito.when(invoice2.getNumberOfItems()).thenReturn(1);
+        Mockito.when(invoice2.getBalance()).thenReturn(BigDecimal.ZERO);
+        Mockito.when(invoice2.getCurrency()).thenReturn(Currency.EUR);
+        final LocalDate firstInvoiceDate = invoice.getInvoiceDate();
+        Mockito.when(invoice2.getInvoiceDate()).thenReturn(firstInvoiceDate.plusDays(1));
+        Mockito.when(killbillAPI.getInvoiceUserApi().getInvoicesByAccount(Mockito.eq(account.getId()),
+                                                                          Mockito.anyBoolean(),
+                                                                          Mockito.anyBoolean(),
+                                                                          Mockito.any(TenantContext.class)))
+               .thenReturn(ImmutableList.of(invoice, invoice2));
+        // Re-create the context to clear caches
+        businessContextFactory = new BusinessContextFactory(account.getId(),
+                                                            callContext,
+                                                            currencyConversionDao,
+                                                            killbillAPI,
+                                                            osgiConfigPropertiesService,
+                                                            clock,
+                                                            analyticsConfigurationHandler);
+
+        // Refresh that new invoice
+        businessInvoiceDao.update(invoiceId2, businessContextFactory);
+
+        // Verify the state
+        final BusinessSnapshot businessSnapshot4 = analyticsUserApi.getBusinessSnapshot(account.getId(), callContext);
+        Assert.assertEquals(businessSnapshot4.getBusinessAccount().getAccountId(), account.getId());
+        Assert.assertEquals(businessSnapshot4.getBusinessAccount().getLastInvoiceId(), invoiceId2);
+        Assert.assertEquals(businessSnapshot4.getBusinessInvoices().size(), 2);
+        for (final BusinessInvoice businessInvoice : businessSnapshot4.getBusinessInvoices()) {
+            if (businessInvoice.getInvoiceId().equals(invoice.getId())) {
+                Assert.assertEquals(businessInvoice.getInvoiceItems().size(), 2);
+                Assert.assertTrue("EXTERNAL_CHARGE".equals(businessInvoice.getInvoiceItems().get(0).getItemType()) && "TAX".equals(businessInvoice.getInvoiceItems().get(1).getItemType()) ||
+                                  "EXTERNAL_CHARGE".equals(businessInvoice.getInvoiceItems().get(1).getItemType()) && "TAX".equals(businessInvoice.getInvoiceItems().get(0).getItemType()));
+            } else {
+                Assert.assertEquals(businessInvoice.getInvoiceId(), invoiceId2);
+                Assert.assertEquals(businessInvoice.getInvoiceItems().size(), 1);
+                Assert.assertEquals(businessInvoice.getInvoiceItems().get(0).getItemType(), "RECURRING");
+            }
+        }
+
+        // Verify only the rows associated with that new invoice have changed
+        final Long bacRecordId3 = analyticsSqlDao.getAccountByAccountRecordId(accountRecordId, tenantRecordId, callContext).getRecordId();
+        Assert.assertTrue(bacRecordId3 > bacRecordId2);
+        final List<BusinessInvoiceModelDao> invoicesByAccountRecordId3 = analyticsSqlDao.getInvoicesByAccountRecordId(accountRecordId, tenantRecordId, callContext);
+        Assert.assertEquals(invoicesByAccountRecordId3.size(), 2);
+        for (final BusinessInvoiceModelDao businessInvoiceModelDao : invoicesByAccountRecordId3) {
+            if (businessInvoiceModelDao.getInvoiceId().equals(invoice.getId())) {
+                // Row hasn't changed
+                Assert.assertEquals(businessInvoiceModelDao.getRecordId(), binRecordId2);
+            } else {
+                Assert.assertTrue(businessInvoiceModelDao.getRecordId() > binRecordId2);
+            }
+        }
+        final List<BusinessInvoiceItemModelDao> invoiceItemsByAccountRecordId3 = analyticsSqlDao.getInvoiceItemsByAccountRecordId(accountRecordId, tenantRecordId, callContext);
+        Assert.assertEquals(invoiceItemsByAccountRecordId3.size(), 3);
+        for (final BusinessInvoiceItemModelDao businessInvoiceItemModelDao : invoiceItemsByAccountRecordId3) {
+            if (businessInvoiceItemModelDao.getItemId().equals(invoiceItem.getId()) || businessInvoiceItemModelDao.getItemId().equals(linkedInvoiceItem.getId())) {
+                // Row hasn't changed
+                Assert.assertTrue(businessInvoiceItemModelDao.getRecordId().equals(biiRecordId21) || businessInvoiceItemModelDao.getRecordId().equals(biiRecordId22));
+            } else {
+                Assert.assertEquals(businessInvoiceItemModelDao.getItemId(), newInvoiceItem.getId());
+                Assert.assertTrue(businessInvoiceItemModelDao.getRecordId() > Math.max(biiRecordId11, biiRecordId12));
+            }
+        }
+    }
+}

--- a/src/test/java/org/killbill/billing/plugin/analytics/dao/factory/TestBusinessInvoiceFactory.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/dao/factory/TestBusinessInvoiceFactory.java
@@ -109,6 +109,7 @@ public class TestBusinessInvoiceFactory extends AnalyticsTestSuiteNoDB {
                                                                                                       invoice,
                                                                                                       adjustmentItem,
                                                                                                       ImmutableList.<InvoiceItem>of(taxItem, recurringItem),
+                                                                                                      recurringItem,
                                                                                                       false,
                                                                                                       bundles,
                                                                                                       currencyConverter,


### PR DESCRIPTION
Only refresh invoice and associated invoice item rows for `INVOICE_CREATION` and `INVOICE_ADJUSTMENT` events. See https://github.com/killbill/killbill-analytics-plugin/issues/93.

Verified the behavior by manual testing (by creating, adjusting and paying individual invoices, and verifying the state is correctly updated).

This depends on https://github.com/killbill/killbill/issues/1143 for accuracy with CBA items.

Things to think about, as a reviewer, since it's a lot of code:

* Is the assumption correct that `INVOICE_CREATION` and `INVOICE_ADJUSTMENT` events just need to update the associated invoice and account rows? The subscription CTD is also impacted for instance, but it looks like we are already missing it today (known bug?).
* `BusinessContextFactory` does a lot of caching, across various objects. Is the logic correct? Is the synchronization correct?
