### PR TITLE
listener: refresh payment rows when CBA is distributed

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsJobHierarchy.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsJobHierarchy.java
@@ -17,12 +17,10 @@
 
 package org.killbill.billing.plugin.analytics;
 
-import org.killbill.billing.notification.plugin.api.ExtBusEventType;
-
 public abstract class AnalyticsJobHierarchy {
 
-    public static Group fromEventType(final ExtBusEventType eventType) {
-        switch (eventType) {
+    public static Group fromEventType(final AnalyticsJob job) {
+        switch (job.getEventType()) {
             // Account information is denormalized across all tables
             case ACCOUNT_CREATION:
             case ACCOUNT_CHANGE:

--- a/src/test/java/org/killbill/billing/plugin/analytics/TestAnalyticsListener.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/TestAnalyticsListener.java
@@ -64,7 +64,7 @@ public class TestAnalyticsListener extends AnalyticsTestSuiteNoDB {
 
         final AnalyticsListener analyticsListener = new AnalyticsListener(killbillAPI, killbillDataSource, osgiConfigPropertiesService, null, clock, analyticsConfigurationHandler, notificationQueueService);
 
-        Assert.assertTrue(analyticsListener.shouldIgnoreEvent(cfEvent));
-        Assert.assertFalse(analyticsListener.shouldIgnoreEvent(accountEvent));
+        Assert.assertTrue(analyticsListener.shouldIgnoreEvent(new AnalyticsJob(cfEvent)));
+        Assert.assertFalse(analyticsListener.shouldIgnoreEvent(new AnalyticsJob(accountEvent)));
     }
 }


### PR DESCRIPTION
In https://github.com/killbill/killbill-analytics-plugin/issues/93, we stopped refreshing payments for `INVOICE_CREATION` and `INVOICE_ADJUSTMENT` events.

Payment rows still need to be updated (if they exist) when CBA is distributed, as the balance may change.

This fixes https://github.com/killbill/killbill-analytics-plugin/issues/105.

## Testing done

Tested with the following scenario:

* Account with `__EXTERNAL_PAYMENT__` default payment method
* Monthly subscription started on 2019-10-01: two invoices and two corresponding invoice payments
* Update the most recent payment from `SUCCESS` to `PAYMENT_FAILURE`

State:

```
[killbill]> select invoice_id, balance, amount_paid, amount_charged, amount_credited from analytics_invoices where account_id = '1cf83538-9117-4386-94da-82c7328ce0b0' order by invoice_number;
+--------------------------------------+---------+-------------+----------------+-----------------+
| invoice_id                           | balance | amount_paid | amount_charged | amount_credited |
+--------------------------------------+---------+-------------+----------------+-----------------+
| 67670acf-4f61-4ab5-9e5f-d9578fad8717 |  0.0000 |     10.0000 |        10.0000 |          0.0000 |
| 290425ac-949b-453a-bb7d-384c5949608c | 10.0000 |      0.0000 |        10.0000 |          0.0000 |
+--------------------------------------+---------+-------------+----------------+-----------------+

[killbill]> select invoice_id, invoice_balance, invoice_amount_paid, invoice_amount_charged, invoice_amount_credited from analytics_payment_purchases where account_id = '1cf83538-9117-4386-94da-82c7328ce0b0' order by invoice_number;
+--------------------------------------+-----------------+---------------------+------------------------+-------------------------+
| invoice_id                           | invoice_balance | invoice_amount_paid | invoice_amount_charged | invoice_amount_credited |
+--------------------------------------+-----------------+---------------------+------------------------+-------------------------+
| 67670acf-4f61-4ab5-9e5f-d9578fad8717 |          0.0000 |             10.0000 |                10.0000 |                  0.0000 |
| 290425ac-949b-453a-bb7d-384c5949608c |         10.0000 |              0.0000 |                10.0000 |                  0.0000 |
+--------------------------------------+-----------------+---------------------+------------------------+-------------------------+
```

* Cancel subscription start of term

State:

```
[killbill]> select invoice_id, balance, amount_paid, amount_charged, amount_credited from analytics_invoices where account_id = '1cf83538-9117-4386-94da-82c7328ce0b0' order by invoice_number;
+--------------------------------------+---------+-------------+----------------+-----------------+
| invoice_id                           | balance | amount_paid | amount_charged | amount_credited |
+--------------------------------------+---------+-------------+----------------+-----------------+
| 67670acf-4f61-4ab5-9e5f-d9578fad8717 |  0.0000 |     10.0000 |        10.0000 |          0.0000 |
| 290425ac-949b-453a-bb7d-384c5949608c |  0.0000 |      0.0000 |        10.0000 |        -10.0000 |
| 70c58d6b-bde6-48cc-b7a6-88dfee843781 |  0.0000 |      0.0000 |       -10.0000 |         10.0000 |
+--------------------------------------+---------+-------------+----------------+-----------------+

[killbill]> select invoice_number, invoice_id, invoice_balance, invoice_amount_paid, invoice_amount_charged, invoice_amount_credited from analytics_payment_purchases where account_id = '1cf83538-9117-4386-94da-82c7328ce0b0' order by invoice_number;
+----------------+--------------------------------------+-----------------+---------------------+------------------------+-------------------------+
| invoice_number | invoice_id                           | invoice_balance | invoice_amount_paid | invoice_amount_charged | invoice_amount_credited |
+----------------+--------------------------------------+-----------------+---------------------+------------------------+-------------------------+
|             38 | 67670acf-4f61-4ab5-9e5f-d9578fad8717 |          0.0000 |             10.0000 |                10.0000 |                  0.0000 |
|             39 | 290425ac-949b-453a-bb7d-384c5949608c |          0.0000 |              0.0000 |                10.0000 |                -10.0000 |
+----------------+--------------------------------------+-----------------+---------------------+------------------------+-------------------------+
```