### PR TITLE
listener: add account-level locking

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -46,6 +46,8 @@
       <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
       <option name="ALIGN_MULTILINE_METHOD_BRACKETS" value="true" />
       <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
+      <option name="CALL_PARAMETERS_WRAP" value="5" />
+      <option name="METHOD_PARAMETERS_WRAP" value="5" />
       <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
       <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
       <option name="IF_BRACE_FORCE" value="3" />

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,10 @@
         </dependency>
         <dependency>
             <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-locker</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-clock</artifactId>
         </dependency>
         <dependency>

--- a/src/test/java/org/killbill/billing/plugin/analytics/AnalyticsTestSuiteNoDB.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/AnalyticsTestSuiteNoDB.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * Ning licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -96,6 +97,8 @@ import org.killbill.billing.util.customfield.CustomField;
 import org.killbill.billing.util.tag.Tag;
 import org.killbill.billing.util.tag.TagDefinition;
 import org.killbill.clock.ClockMock;
+import org.killbill.commons.locker.GlobalLocker;
+import org.killbill.commons.locker.memory.MemoryGlobalLocker;
 import org.killbill.notificationq.DefaultNotificationQueueService;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -111,6 +114,8 @@ public abstract class AnalyticsTestSuiteNoDB {
 
     private static final DateTime INVOICE_CREATED_DATE = new DateTime(2016, 1, 22, 10, 56, 53, DateTimeZone.UTC);
     protected final Logger logger = LoggerFactory.getLogger(AnalyticsTestSuiteNoDB.class);
+
+    protected final GlobalLocker locker = new MemoryGlobalLocker();
 
     protected final Long accountRecordId = 1L;
     protected final Long subscriptionEventRecordId = 2L;

--- a/src/test/java/org/killbill/billing/plugin/analytics/AnalyticsTestSuiteWithEmbeddedDB.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/AnalyticsTestSuiteWithEmbeddedDB.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2016 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the

--- a/src/test/java/org/killbill/billing/plugin/analytics/TestAnalyticsListener.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/TestAnalyticsListener.java
@@ -34,7 +34,14 @@ public class TestAnalyticsListener extends AnalyticsTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testBlacklist() throws Exception {
-        final AnalyticsListener analyticsListener = new AnalyticsListener(killbillAPI, killbillDataSource, osgiConfigPropertiesService, null, clock, analyticsConfigurationHandler, notificationQueueService);
+        final AnalyticsListener analyticsListener = new AnalyticsListener(killbillAPI,
+                                                                          killbillDataSource,
+                                                                          osgiConfigPropertiesService,
+                                                                          null,
+                                                                          locker,
+                                                                          clock,
+                                                                          analyticsConfigurationHandler,
+                                                                          notificationQueueService);
 
         // Other accounts are blacklisted
         Assert.assertFalse(analyticsListener.isAccountBlacklisted(UUID.randomUUID()));
@@ -62,7 +69,14 @@ public class TestAnalyticsListener extends AnalyticsTestSuiteNoDB {
             }
         });
 
-        final AnalyticsListener analyticsListener = new AnalyticsListener(killbillAPI, killbillDataSource, osgiConfigPropertiesService, null, clock, analyticsConfigurationHandler, notificationQueueService);
+        final AnalyticsListener analyticsListener = new AnalyticsListener(killbillAPI,
+                                                                          killbillDataSource,
+                                                                          osgiConfigPropertiesService,
+                                                                          null,
+                                                                          locker,
+                                                                          clock,
+                                                                          analyticsConfigurationHandler,
+                                                                          notificationQueueService);
 
         Assert.assertTrue(analyticsListener.shouldIgnoreEvent(new AnalyticsJob(cfEvent)));
         Assert.assertFalse(analyticsListener.shouldIgnoreEvent(new AnalyticsJob(accountEvent)));

--- a/src/test/java/org/killbill/billing/plugin/analytics/TestAnalyticsNotificationQueue.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/TestAnalyticsNotificationQueue.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -22,6 +22,7 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import org.killbill.billing.notification.plugin.api.ExtBusEvent;
 import org.killbill.billing.notification.plugin.api.ExtBusEventType;
 import org.killbill.notificationq.api.NotificationEventWithMetadata;
@@ -29,15 +30,20 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import org.awaitility.Awaitility;
-
 import com.google.common.collect.Iterables;
 
 public class TestAnalyticsNotificationQueue extends AnalyticsTestSuiteWithEmbeddedDB {
 
     @Test(groups = "slow")
     public void testSendOneEvent() throws Exception {
-        final AnalyticsListener analyticsListener = new AnalyticsListener(killbillAPI, killbillDataSource, osgiConfigPropertiesService, BusinessExecutor.newCachedThreadPool(osgiConfigPropertiesService), clock, analyticsConfigurationHandler, notificationQueueService);
+        final AnalyticsListener analyticsListener = new AnalyticsListener(killbillAPI,
+                                                                          killbillDataSource,
+                                                                          osgiConfigPropertiesService,
+                                                                          BusinessExecutor.newCachedThreadPool(osgiConfigPropertiesService),
+                                                                          locker,
+                                                                          clock,
+                                                                          analyticsConfigurationHandler,
+                                                                          notificationQueueService);
         analyticsListener.start();
 
         // Verify the original state
@@ -62,7 +68,14 @@ public class TestAnalyticsNotificationQueue extends AnalyticsTestSuiteWithEmbedd
 
     @Test(groups = "slow")
     public void testVerifyNoDups() throws Exception {
-        final AnalyticsListener analyticsListener = new AnalyticsListener(killbillAPI, killbillDataSource, osgiConfigPropertiesService, BusinessExecutor.newCachedThreadPool(osgiConfigPropertiesService), clock, analyticsConfigurationHandler, notificationQueueService);
+        final AnalyticsListener analyticsListener = new AnalyticsListener(killbillAPI,
+                                                                          killbillDataSource,
+                                                                          osgiConfigPropertiesService,
+                                                                          BusinessExecutor.newCachedThreadPool(osgiConfigPropertiesService),
+                                                                          locker,
+                                                                          clock,
+                                                                          analyticsConfigurationHandler,
+                                                                          notificationQueueService);
         // Don't start the dequeuer
         Assert.assertEquals(Iterables.<NotificationEventWithMetadata>size(analyticsListener.getJobQueue().getFutureNotificationForSearchKeys(accountRecordId, tenantRecordId)), 0);
 


### PR DESCRIPTION
Groups `INVOICES` and `INVOICE_AND_PAYMENTS` can overlap: add account-level locking as a workaround.
