### PR TITLE
listener: fix jobsOverlap implementation

### DIFF
--- a/src/test/java/org/killbill/billing/plugin/analytics/TestAnalyticsListener.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/TestAnalyticsListener.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -81,5 +81,53 @@ public class TestAnalyticsListener extends AnalyticsTestSuiteNoDB {
 
         Assert.assertTrue(analyticsListener.shouldIgnoreEvent(new AnalyticsJob(cfEvent)));
         Assert.assertFalse(analyticsListener.shouldIgnoreEvent(new AnalyticsJob(accountEvent)));
+    }
+
+
+    @Test(groups = "fast", description = "https://github.com/killbill/killbill-analytics-plugin/issues/118")
+    public void testJobsOverlap() throws Exception {
+        final AnalyticsListener analyticsListener = new AnalyticsListener(killbillAPI,
+                                                                          killbillDataSource,
+                                                                          osgiConfigPropertiesService,
+                                                                          null,
+                                                                          locker,
+                                                                          clock,
+                                                                          analyticsConfigurationHandler,
+                                                                          notificationQueueService);
+
+        final UUID accountId = UUID.randomUUID();
+        final UUID accountId2 = UUID.randomUUID();
+        final UUID invoiceId1 = UUID.randomUUID();
+        final UUID invoiceId2 = UUID.randomUUID();
+        final UUID invoiceId3 = UUID.randomUUID();
+
+        final ExtBusEvent inv1CreationEvent = Mockito.mock(ExtBusEvent.class);
+        Mockito.when(inv1CreationEvent.getAccountId()).thenReturn(accountId);
+        Mockito.when(inv1CreationEvent.getObjectId()).thenReturn(invoiceId1);
+        Mockito.when(inv1CreationEvent.getEventType()).thenReturn(ExtBusEventType.INVOICE_CREATION);
+
+        final ExtBusEvent inv1AdjEvent = Mockito.mock(ExtBusEvent.class);
+        Mockito.when(inv1AdjEvent.getAccountId()).thenReturn(accountId);
+        Mockito.when(inv1AdjEvent.getObjectId()).thenReturn(invoiceId1);
+        Mockito.when(inv1AdjEvent.getEventType()).thenReturn(ExtBusEventType.INVOICE_ADJUSTMENT);
+
+        final ExtBusEvent inv2AdjEvent = Mockito.mock(ExtBusEvent.class);
+        Mockito.when(inv2AdjEvent.getAccountId()).thenReturn(accountId);
+        Mockito.when(inv2AdjEvent.getObjectId()).thenReturn(invoiceId2);
+        Mockito.when(inv2AdjEvent.getEventType()).thenReturn(ExtBusEventType.INVOICE_ADJUSTMENT);
+
+        final ExtBusEvent inv3CreationEvent = Mockito.mock(ExtBusEvent.class);
+        Mockito.when(inv3CreationEvent.getAccountId()).thenReturn(accountId2);
+        Mockito.when(inv3CreationEvent.getObjectId()).thenReturn(invoiceId3);
+        Mockito.when(inv3CreationEvent.getEventType()).thenReturn(ExtBusEventType.INVOICE_CREATION);
+
+        // Same job
+        Assert.assertTrue(analyticsListener.jobsOverlap(new AnalyticsJob(inv1CreationEvent), new AnalyticsJob(inv1CreationEvent)));
+        // Different accounts
+        Assert.assertFalse(analyticsListener.jobsOverlap(new AnalyticsJob(inv3CreationEvent), new AnalyticsJob(inv1CreationEvent)));
+        // Adjustment event for the same invoice
+        Assert.assertTrue(analyticsListener.jobsOverlap(new AnalyticsJob(inv1AdjEvent), new AnalyticsJob(inv1CreationEvent)));
+        // Adjustment event for another invoice
+        Assert.assertFalse(analyticsListener.jobsOverlap(new AnalyticsJob(inv2AdjEvent), new AnalyticsJob(inv1CreationEvent)));
     }
 }

--- a/src/test/java/org/killbill/billing/plugin/analytics/TestAnalyticsNotificationQueue.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/TestAnalyticsNotificationQueue.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -84,7 +84,9 @@ public class TestAnalyticsNotificationQueue extends AnalyticsTestSuiteWithEmbedd
         Assert.assertEquals(analyticsSqlDao.getAccountFieldsByAccountRecordId(accountRecordId, tenantRecordId, callContext).size(), 0);
 
         // Send the first event
+        final UUID objectId = UUID.randomUUID();
         final ExtBusEvent firstEvent = createExtBusEvent();
+        Mockito.when(firstEvent.getObjectId()).thenReturn(objectId);
         Mockito.when(firstEvent.getEventType()).thenReturn(ExtBusEventType.PAYMENT_FAILED);
         analyticsListener.handleKillbillEvent(firstEvent);
 
@@ -99,6 +101,7 @@ public class TestAnalyticsNotificationQueue extends AnalyticsTestSuiteWithEmbedd
 
         // Now, send a different event type
         final ExtBusEvent secondEvent = createExtBusEvent();
+        Mockito.when(secondEvent.getObjectId()).thenReturn(objectId);
         Mockito.when(secondEvent.getEventType()).thenReturn(ExtBusEventType.OVERDUE_CHANGE);
         analyticsListener.handleKillbillEvent(secondEvent);
 
@@ -107,6 +110,7 @@ public class TestAnalyticsNotificationQueue extends AnalyticsTestSuiteWithEmbedd
 
         // Now, send a different event type, but triggering the same refresh type as the first event
         final ExtBusEvent thirdEvent = createExtBusEvent();
+        Mockito.when(thirdEvent.getObjectId()).thenReturn(objectId);
         Mockito.when(thirdEvent.getEventType()).thenReturn(ExtBusEventType.PAYMENT_SUCCESS);
         analyticsListener.handleKillbillEvent(thirdEvent);
 


### PR DESCRIPTION
Now that we do partial refreshes, the logic to check for overlapping jobs must take into account the object being refreshed.

This fixes https://github.com/killbill/killbill-analytics-plugin/issues/118.

FYI @reshmabidikar