### PR TITLE
invoice: fix inconsistency with non COMMITTED invoices

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.49</version>
+        <version>0.144.51</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>analytics-plugin</artifactId>

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/model/BusinessInvoiceModelDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/model/BusinessInvoiceModelDao.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -58,6 +58,8 @@ public class BusinessInvoiceModelDao extends BusinessModelDaoBase {
     private BigDecimal convertedAmountRefunded;
     private String convertedCurrency;
     private boolean writtenOff;
+    // Not in DB schema
+    private String status;
 
     public BusinessInvoiceModelDao() { /* When reading from the database */ }
 
@@ -83,6 +85,7 @@ public class BusinessInvoiceModelDao extends BusinessModelDaoBase {
                                    final BigDecimal convertedAmountRefunded,
                                    final String convertedCurrency,
                                    final boolean writtenOff,
+                                   final String status,
                                    final DateTime createdDate,
                                    final String createdBy,
                                    final String createdReasonCode,
@@ -125,6 +128,7 @@ public class BusinessInvoiceModelDao extends BusinessModelDaoBase {
         this.convertedAmountRefunded = convertedAmountRefunded;
         this.convertedCurrency = convertedCurrency;
         this.writtenOff = writtenOff;
+        this.status = status;
     }
 
     public BusinessInvoiceModelDao(final Account account,
@@ -158,6 +162,7 @@ public class BusinessInvoiceModelDao extends BusinessModelDaoBase {
              currencyConverter.getConvertedValue(invoice.getRefundedAmount(), invoice),
              currencyConverter.getConvertedCurrency(),
              writtenOff,
+             invoice.getStatus().toString(),
              invoice.getCreatedDate(),
              creationAuditLog != null ? creationAuditLog.getUserName() : null,
              creationAuditLog != null ? creationAuditLog.getReasonCode() : null,
@@ -263,6 +268,10 @@ public class BusinessInvoiceModelDao extends BusinessModelDaoBase {
         return writtenOff;
     }
 
+    public String getStatus() {
+        return status;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("BusinessInvoiceModelDao{");
@@ -288,6 +297,7 @@ public class BusinessInvoiceModelDao extends BusinessModelDaoBase {
         sb.append(", convertedAmountRefunded=").append(convertedAmountRefunded);
         sb.append(", convertedCurrency='").append(convertedCurrency).append('\'');
         sb.append(", writtenOff='").append(writtenOff).append('\'');
+        /* sb.append(", status='").append(status).append('\''); // Not read from DB */
         sb.append('}');
         return sb.toString();
     }
@@ -366,6 +376,12 @@ public class BusinessInvoiceModelDao extends BusinessModelDaoBase {
         if (rawBalance != null ? rawBalance.compareTo(that.rawBalance) != 0 : that.rawBalance != null) {
             return false;
         }
+        /*
+        // Not read from DB
+        if (status != null ? !status.equals(that.status) : that.status != null) {
+            return false;
+        }
+        */
         if (targetDate != null ? targetDate.compareTo(that.targetDate) != 0 : that.targetDate != null) {
             return false;
         }
@@ -401,6 +417,7 @@ public class BusinessInvoiceModelDao extends BusinessModelDaoBase {
         result = 31 * result + (convertedAmountRefunded != null ? convertedAmountRefunded.hashCode() : 0);
         result = 31 * result + (convertedCurrency != null ? convertedCurrency.hashCode() : 0);
         result = 31 * result + (writtenOff ? 1 : 0);
+        /* result = 31 * result + (status != null ? status.hashCode() : 0); // Not read from DB */
         return result;
     }
 }

--- a/src/test/java/org/killbill/billing/plugin/analytics/AnalyticsTestSuiteNoDB.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/AnalyticsTestSuiteNoDB.java
@@ -57,6 +57,7 @@ import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.api.InvoicePayment;
 import org.killbill.billing.invoice.api.InvoicePaymentType;
+import org.killbill.billing.invoice.api.InvoiceStatus;
 import org.killbill.billing.invoice.api.InvoiceUserApi;
 import org.killbill.billing.osgi.libs.killbill.OSGIConfigPropertiesService;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
@@ -412,6 +413,7 @@ public abstract class AnalyticsTestSuiteNoDB {
         Mockito.when(invoice.getBalance()).thenReturn(new BigDecimal("12001"));
         Mockito.when(invoice.isMigrationInvoice()).thenReturn(false);
         Mockito.when(invoice.getCreatedDate()).thenReturn(INVOICE_CREATED_DATE);
+        Mockito.when(invoice.getStatus()).thenReturn(InvoiceStatus.COMMITTED);
 
         final PaymentMethodPlugin paymentMethodPlugin = Mockito.mock(PaymentMethodPlugin.class);
         Mockito.when(paymentMethodPlugin.getExternalPaymentMethodId()).thenReturn(UUID.randomUUID().toString());


### PR DESCRIPTION
Full refreshes are ignoring non COMMITTED invoices: ensure partial refreshes do the same for consistency.

DRAFT and VOID invoices are currently not present in the analytics tables. We could consider populating them eventually, although a new status column would need to be added for the related table(s).
