### PR TITLE
dao: reduce number of calls to getLatestSubscriptionBundleForExternalKey

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessContextFactory.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessContextFactory.java
@@ -217,6 +217,14 @@ public class BusinessContextFactory extends BusinessFactoryBase {
             synchronized (this) {
                 if (accountBundles == null) {
                     accountBundles = getSubscriptionBundlesForAccount(accountId, callContext);
+
+                    // Pre-populate latestSubscriptionBundleForExternalKeys cache to avoid calling getLatestSubscriptionBundleForExternalKey for each bundle
+                    for (final SubscriptionBundle subscriptionBundle : accountBundles) {
+                        if (latestSubscriptionBundleForExternalKeys.get(subscriptionBundle.getExternalKey()) == null ||
+                            latestSubscriptionBundleForExternalKeys.get(subscriptionBundle.getExternalKey()).getCreatedDate().compareTo(subscriptionBundle.getCreatedDate()) > 0) {
+                            latestSubscriptionBundleForExternalKeys.put(subscriptionBundle.getExternalKey(), subscriptionBundle);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
With this fix, an account with 30k+ bundles (120k+ subscription transitions) can be refreshed in ~1m30 with warm caches.