### PR TITLE
locker: make timeout and retries configurable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 7.2.4
     Make all properties dynamic (the System Properties have been deprecated, see README for a configuration example)
+    Introduce lockAttemptRetries, rescheduleIntervalOnLockSeconds, and enablePartialRefreshes (per tenant)
+    Introduce org.killbill.analytics.lockSleepMilliSeconds (global)
+    Performance improvements
 
 7.2.3
     Fix inconsistency with non COMMITTED invoices (requires Kill Bill 0.22.24)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ kpm install_java_plugin analytics --from-source-file target/analytics-plugin-*-S
 
 ## Configuration
 
+### Per tenant
+
 ```
 curl -v \
      -X POST \
@@ -45,6 +47,7 @@ curl -v \
      -H 'Content-Type: text/plain' \
      -d '!!org.killbill.billing.plugin.analytics.api.core.AnalyticsConfiguration
   refreshDelaySeconds: 10
+  lockAttemptRetries: 100
   blacklist:
     - 468e5259-6635-4988-9ae7-3d79b11fc6ed
     - f7da09af-8593-4a88-b6d4-1c4ebf807103
@@ -60,6 +63,14 @@ curl -v \
       type: trino
       url: jdbc:trino://example.net:8080/hive/sales?user=admin' \
     http://127.0.0.1:8080/1.0/kb/tenants/uploadPluginConfig/killbill-analytics
+```
+
+### Global
+
+```
+org.killbill.notificationq.analytics.tableName=analytics_notifications
+org.killbill.notificationq.analytics.historyTableName=analytics_notifications_history
+org.killbill.analytics.lockSleepMilliSeconds=100
 ```
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ curl -v \
   refreshDelaySeconds: 10
   lockAttemptRetries: 100
   rescheduleIntervalOnLockSeconds: 10
+  enablePartialRefreshes: true
   blacklist:
     - 468e5259-6635-4988-9ae7-3d79b11fc6ed
     - f7da09af-8593-4a88-b6d4-1c4ebf807103

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ curl -v \
      -d '!!org.killbill.billing.plugin.analytics.api.core.AnalyticsConfiguration
   refreshDelaySeconds: 10
   lockAttemptRetries: 100
+  rescheduleIntervalOnLockSeconds: 10
   blacklist:
     - 468e5259-6635-4988-9ae7-3d79b11fc6ed
     - f7da09af-8593-4a88-b6d4-1c4ebf807103

--- a/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsJob.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsJob.java
@@ -1,8 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -24,36 +24,45 @@ import java.util.UUID;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.notification.plugin.api.ExtBusEvent;
 import org.killbill.billing.notification.plugin.api.ExtBusEventType;
+import org.killbill.billing.plugin.analytics.AnalyticsJobHierarchy.Group;
 import org.killbill.notificationq.api.NotificationEvent;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class AnalyticsJob implements NotificationEvent {
 
+    private final Group group;
     private final ExtBusEventType eventType;
     private final ObjectType objectType;
     private final UUID objectId;
     private final UUID accountId;
     private final UUID tenantId;
 
-    public AnalyticsJob(final ExtBusEvent extBusEvent) {
-        this(extBusEvent.getEventType(),
+    public AnalyticsJob(final ExtBusEvent extBusEvent, final Group group) {
+        this(group,
+             extBusEvent.getEventType(),
              extBusEvent.getObjectType(),
              extBusEvent.getObjectId(),
              extBusEvent.getAccountId(),
              extBusEvent.getTenantId());
     }
 
-    public AnalyticsJob(@JsonProperty("eventType") final ExtBusEventType eventType,
+    public AnalyticsJob(@JsonProperty("group") final Group group,
+                        @JsonProperty("eventType") final ExtBusEventType eventType,
                         @JsonProperty("objectType") final ObjectType objectType,
                         @JsonProperty("objectId") final UUID objectId,
                         @JsonProperty("accountId") final UUID accountId,
                         @JsonProperty("tenantId") final UUID tenantId) {
+        this.group = group;
         this.eventType = eventType;
         this.objectType = objectType;
         this.objectId = objectId;
         this.accountId = accountId;
         this.tenantId = tenantId;
+    }
+
+    public Group getGroup() {
+        return group;
     }
 
     public ExtBusEventType getEventType() {
@@ -79,7 +88,8 @@ public class AnalyticsJob implements NotificationEvent {
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("AnalyticsJob{");
-        sb.append("eventType=").append(eventType);
+        sb.append("group=").append(group);
+        sb.append(", eventType=").append(eventType);
         sb.append(", objectType=").append(objectType);
         sb.append(", objectId=").append(objectId);
         sb.append(", accountId=").append(accountId);
@@ -105,6 +115,9 @@ public class AnalyticsJob implements NotificationEvent {
         if (eventType != job.eventType) {
             return false;
         }
+        if (group != null ? !group.equals(job.group) : job.group != null) {
+            return false;
+        }
         if (objectId != null ? !objectId.equals(job.objectId) : job.objectId != null) {
             return false;
         }
@@ -121,6 +134,7 @@ public class AnalyticsJob implements NotificationEvent {
     @Override
     public int hashCode() {
         int result = eventType != null ? eventType.hashCode() : 0;
+        result = 31 * result + (group != null ? group.hashCode() : 0);
         result = 31 * result + (objectType != null ? objectType.hashCode() : 0);
         result = 31 * result + (objectId != null ? objectId.hashCode() : 0);
         result = 31 * result + (accountId != null ? accountId.hashCode() : 0);

--- a/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsJobHierarchy.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsJobHierarchy.java
@@ -19,10 +19,12 @@
 
 package org.killbill.billing.plugin.analytics;
 
+import org.killbill.billing.notification.plugin.api.ExtBusEventType;
+
 public abstract class AnalyticsJobHierarchy {
 
-    public static Group fromEventType(final AnalyticsJob job) {
-        switch (job.getEventType()) {
+    public static Group fromEventType(final ExtBusEventType extBusEventType) {
+        switch (extBusEventType) {
             // Account information is denormalized across all tables
             case ACCOUNT_CREATION:
             case ACCOUNT_CHANGE:

--- a/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsListener.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsListener.java
@@ -298,7 +298,7 @@ public class AnalyticsListener implements OSGIKillbillEventDispatcher.OSGIKillbi
     private void handleAnalyticsJob(final AnalyticsJob job) throws AnalyticsRefreshException {
         GlobalLock lock = null;
         try {
-            lock = locker.lockWithNumberOfTries("ANALYTICS_REFRESH", job.getAccountId().toString(), 100);
+            lock = locker.lockWithNumberOfTries("ANALYTICS_REFRESH", job.getAccountId().toString(), analyticsConfigurationHandler.getConfigurable(job.getTenantId()).lockAttemptRetries);
             handleAnalyticsJobWithLock(job);
         } catch (final LockFailedException e) {
             throw new RuntimeException(e);

--- a/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsListener.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsListener.java
@@ -69,6 +69,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
@@ -168,20 +169,24 @@ public class AnalyticsListener implements OSGIKillbillEventDispatcher.OSGIKillbi
             return;
         }
 
+        final AnalyticsConfiguration analyticsConfiguration = analyticsConfigurationHandler.getConfigurable(killbillEvent.getTenantId());
+
         // Don't mirror accounts in the blacklist
-        if (isAccountBlacklisted(killbillEvent.getAccountId(), killbillEvent.getTenantId())) {
+        if (isAccountBlacklisted(killbillEvent.getAccountId(), analyticsConfiguration)) {
             return;
         }
 
-        AnalyticsJob job = new AnalyticsJob(killbillEvent);
-        if (AnalyticsJobHierarchy.fromEventType(job) == Group.INVOICES) {
+        final Group group = analyticsConfiguration.enablePartialRefreshes ? AnalyticsJobHierarchy.fromEventType(killbillEvent.getEventType()) : Group.ALL;
+        AnalyticsJob job = new AnalyticsJob(killbillEvent, group);
+        if (group == Group.INVOICES) {
             try {
                 final TenantContext tenantContext = new PluginTenantContext(killbillEvent.getAccountId(), killbillEvent.getTenantId());
                 final Invoice invoice = osgiKillbillAPI.getInvoiceUserApi().getInvoice(killbillEvent.getObjectId(), tenantContext);
                 if (BigDecimal.ZERO.compareTo(invoice.getCreditedAmount()) != 0 && invoice.getNumberOfPayments() > 0) {
                     // The invoice has payments and CBA was updated: payment rows must be updated
                     // See https://github.com/killbill/killbill-analytics-plugin/issues/105
-                    job = new AnalyticsJob(PAYMENT_SUCCESS,
+                    job = new AnalyticsJob(AnalyticsJobHierarchy.fromEventType(PAYMENT_SUCCESS),
+                                           PAYMENT_SUCCESS,
                                            killbillEvent.getObjectType(),
                                            killbillEvent.getObjectId(),
                                            killbillEvent.getAccountId(),
@@ -193,14 +198,14 @@ public class AnalyticsListener implements OSGIKillbillEventDispatcher.OSGIKillbi
         }
 
         // Events we don't care about
-        if (shouldIgnoreEvent(job)) {
+        if (shouldIgnoreEvent(group, analyticsConfiguration)) {
             return;
         }
 
-        scheduleAnalyticsJob(job);
+        scheduleAnalyticsJob(job, analyticsConfiguration);
     }
 
-    private boolean scheduleAnalyticsJob(final AnalyticsJob job) {
+    private boolean scheduleAnalyticsJob(final AnalyticsJob job, final AnalyticsConfiguration analyticsConfiguration) {
         final Long accountRecordId;
         final Long tenantRecordId;
         final RecordIdApi recordIdApi = osgiKillbillAPI.getRecordIdApi();
@@ -222,7 +227,7 @@ public class AnalyticsListener implements OSGIKillbillEventDispatcher.OSGIKillbi
         }
 
         try {
-            jobQueue.recordFutureNotification(computeFutureNotificationTime(job.getTenantId()), job, UUID.randomUUID(), accountRecordId, tenantRecordId);
+            jobQueue.recordFutureNotification(computeFutureNotificationTime(analyticsConfiguration), job, UUID.randomUUID(), accountRecordId, tenantRecordId);
             return true;
         } catch (final IOException e) {
             logger.warn("Unable to record notification for job {}", job);
@@ -287,7 +292,9 @@ public class AnalyticsListener implements OSGIKillbillEventDispatcher.OSGIKillbi
     // Does the specified existing notification overlap with this job?
     @VisibleForTesting
     boolean jobsOverlap(final AnalyticsJob job, final AnalyticsJob existingJob) {
-        final AnalyticsJobHierarchy.Group existingHierarchyGroup = AnalyticsJobHierarchy.fromEventType(existingJob);
+        // Pre 7.2.4, the group wasn't stored in the event
+        final Group existingHierarchyGroup = MoreObjects.firstNonNull(existingJob.getGroup(), AnalyticsJobHierarchy.fromEventType(existingJob.getEventType()));
+        final Group hierarchyGroup = MoreObjects.firstNonNull(job.getGroup(), AnalyticsJobHierarchy.fromEventType(job.getEventType()));
 
         if (!existingJob.getAccountId().equals(job.getAccountId())) {
             // Jobs for different accounts, they cannot overlap
@@ -295,7 +302,7 @@ public class AnalyticsListener implements OSGIKillbillEventDispatcher.OSGIKillbi
         } else if (Group.ALL.equals(existingHierarchyGroup)) {
             // A full refresh is already scheduled, the new job overlaps
             return true;
-        } else if (existingHierarchyGroup.equals(AnalyticsJobHierarchy.fromEventType(job)) &&
+        } else if (existingHierarchyGroup.equals(hierarchyGroup) &&
                    job.getObjectId() != null && existingJob.getObjectId() != null && job.getObjectId().equals(existingJob.getObjectId())) {
             // A refresh for the same group and object is already scheduled
             return true;
@@ -311,7 +318,7 @@ public class AnalyticsListener implements OSGIKillbillEventDispatcher.OSGIKillbi
             final Integer delaySec = analyticsConfiguration.rescheduleIntervalOnLockSeconds;
             if (delaySec > 0) {
                 final DateTime nextRescheduleDt = clock.getUTCNow().plusSeconds(delaySec);
-                if (scheduleAnalyticsJob(job)) {
+                if (scheduleAnalyticsJob(job, analyticsConfiguration)) {
                     logger.info("Lock is busy for account {}, rescheduling job at time {}", job.getAccountId(), nextRescheduleDt);
                     return;
                 }
@@ -339,7 +346,8 @@ public class AnalyticsListener implements OSGIKillbillEventDispatcher.OSGIKillbi
         final CallContext callContext = new AnalyticsCallContext(job, clock);
         final BusinessContextFactory businessContextFactory = new BusinessContextFactory(job.getAccountId(), callContext, currencyConversionDao, osgiKillbillAPI, osgiConfigPropertiesService, clock, analyticsConfigurationHandler);
 
-        final Group group = AnalyticsJobHierarchy.fromEventType(job);
+        // Pre 7.2.4, the group wasn't stored in the event
+        final Group group = MoreObjects.firstNonNull(job.getGroup(), AnalyticsJobHierarchy.fromEventType(job.getEventType()));
         logger.info("Starting {} Analytics refresh for account {}", group, businessContextFactory.getAccountId());
         switch (group) {
             case ALL:
@@ -367,25 +375,25 @@ public class AnalyticsListener implements OSGIKillbillEventDispatcher.OSGIKillbi
         logger.info("Finished Analytics refresh for account {}", businessContextFactory.getAccountId());
     }
 
-    private DateTime computeFutureNotificationTime(final UUID tenantId) {
-        return clock.getUTCNow().plusSeconds(analyticsConfigurationHandler.getConfigurable(tenantId).refreshDelaySeconds);
+    private DateTime computeFutureNotificationTime(final AnalyticsConfiguration analyticsConfiguration) {
+        return clock.getUTCNow().plusSeconds(analyticsConfiguration.refreshDelaySeconds);
     }
 
     @VisibleForTesting
-    protected boolean isAccountBlacklisted(@Nullable final UUID accountId, final UUID tenantId) {
-        return accountId != null && Iterables.find(analyticsConfigurationHandler.getConfigurable(tenantId).blacklist, Predicates.<String>equalTo(accountId.toString()), null) != null;
+    protected boolean isAccountBlacklisted(@Nullable final UUID accountId, final AnalyticsConfiguration analyticsConfiguration) {
+        return accountId != null && Iterables.find(analyticsConfiguration.blacklist, Predicates.<String>equalTo(accountId.toString()), null) != null;
     }
 
     @VisibleForTesting
-    protected boolean shouldIgnoreEvent(final AnalyticsJob job) {
-        final Iterable<Group> ignoredGroups = Iterables.<String, Group>transform(analyticsConfigurationHandler.getConfigurable(job.getTenantId()).ignoredGroups,
+    protected boolean shouldIgnoreEvent(final Group group, final AnalyticsConfiguration analyticsConfiguration) {
+        final Iterable<Group> ignoredGroups = Iterables.<String, Group>transform(analyticsConfiguration.ignoredGroups,
                                                                                  new Function<String, Group>() {
                                                                                      @Override
                                                                                      public Group apply(final String input) {
                                                                                          return input == null ? null : Group.valueOf(input.toUpperCase());
                                                                                      }
                                                                                  });
-        return Iterables.find(ignoredGroups, Predicates.<Group>equalTo(AnalyticsJobHierarchy.fromEventType(job)), null) != null;
+        return Iterables.find(ignoredGroups, Predicates.<Group>equalTo(group), null) != null;
     }
 
     @VisibleForTesting

--- a/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
@@ -47,6 +47,8 @@ public class AnalyticsConfiguration {
     public Integer refreshDelaySeconds = 10;
     // How many retries to get the lock
     public Integer lockAttemptRetries = 100;
+    // If the lock is taken, how long until the job is rescheduled
+    public Integer rescheduleIntervalOnLockSeconds = 10;
 
     public Map<String, Map<Integer, String>> pluginPropertyKeys = new HashMap<String, Map<Integer, String>>();
     public Map<String, Map<String, String>> databases = new HashMap<String, Map<String, String>>();

--- a/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
@@ -45,6 +45,9 @@ public class AnalyticsConfiguration {
     // for a given account (e.g. create account, add payment method, create payment), this makes sure we have the latest state
     // when starting the refresh (since only the first event will trigger the refresh, all others are ignored).
     public Integer refreshDelaySeconds = 10;
+    // How many retries to get the lock
+    public Integer lockAttemptRetries = 100;
+
     public Map<String, Map<Integer, String>> pluginPropertyKeys = new HashMap<String, Map<Integer, String>>();
     public Map<String, Map<String, String>> databases = new HashMap<String, Map<String, String>>();
 

--- a/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
@@ -49,6 +49,8 @@ public class AnalyticsConfiguration {
     public Integer lockAttemptRetries = 100;
     // If the lock is taken, how long until the job is rescheduled
     public Integer rescheduleIntervalOnLockSeconds = 10;
+    // Whether to trigger full refreshes each time
+    public boolean enablePartialRefreshes = true;
 
     public Map<String, Map<Integer, String>> pluginPropertyKeys = new HashMap<String, Map<Integer, String>>();
     public Map<String, Map<String, String>> databases = new HashMap<String, Map<String, String>>();

--- a/src/main/java/org/killbill/billing/plugin/analytics/utils/CurrencyConverter.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/utils/CurrencyConverter.java
@@ -116,8 +116,8 @@ public class CurrencyConverter {
         return getConvertedValue(invoiceItem.getAmount(), invoiceItem.getCurrency().toString(), invoice.getInvoiceDate());
     }
 
-    public BigDecimal getConvertedValue(@Nullable final InvoicePayment invoicePayment, final PaymentTransaction transaction, final Invoice invoice) {
-        if (invoicePayment != null && invoicePayment.getAmount() != null) {
+    public BigDecimal getConvertedValue(@Nullable final InvoicePayment invoicePayment, final PaymentTransaction transaction, @Nullable final Invoice invoice) {
+        if (invoicePayment != null && invoicePayment.getAmount() != null && invoicePayment.getCurrency() != null && invoice != null) {
             // Use the invoice date as the effective date for consistency - invoice payment payment date could also be a candidate
             return getConvertedValue(invoicePayment.getAmount(), invoicePayment.getCurrency().toString(), invoice.getInvoiceDate());
         } else if (transaction.getCurrency() != null) {


### PR DESCRIPTION
If refresh for a very large account takes 2 minutes for instance, and you don't want to increase `refreshDelaySeconds` which would penalize small accounts, you can now increase the lock timeout delay.

Globally (`killbill.properties`):

```
org.killbill.analytics.lockSleepMilliSeconds=1000
```

Per tenant:

```
lockAttemptRetries: 150
```
