### PR TITLE
activator: warn if the shutdown sequence times out

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+7.2.5
+    Better support for long shutdown sequences
+    Update to killbill-oss-parent 0.144.61
+
 7.2.4
     Make all properties dynamic (the System Properties have been deprecated, see README for a configuration example)
     Introduce lockAttemptRetries, rescheduleIntervalOnLockSeconds, and enablePartialRefreshes (per tenant)

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.59</version>
+        <version>0.144.61</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>analytics-plugin</artifactId>

--- a/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsActivator.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsActivator.java
@@ -173,11 +173,15 @@ public class AnalyticsActivator extends KillbillActivatorBase {
 
     @Override
     public void stop(final BundleContext context) throws Exception {
-        if (analyticsListener != null) {
-            analyticsListener.shutdownNow();
-        }
         if (jobsScheduler != null) {
             jobsScheduler.shutdownNow();
+        }
+        if (analyticsListener != null) {
+            // Little bit of subtlety here, which is queue implementation dependent: only the second time
+            // the queue is asked to stop that it will actually go through the shutdown sequence
+            if (!analyticsListener.shutdownNow()) {
+                logger.warn("Timed out while shutting down Analytics notifications queue: IN_PROCESSING entries might be left behind");
+            }
         }
         if (reportsUserApi != null) {
             reportsUserApi.shutdownNow();

--- a/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsListener.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsListener.java
@@ -154,8 +154,8 @@ public class AnalyticsListener implements OSGIKillbillEventDispatcher.OSGIKillbi
         jobQueue.startQueue();
     }
 
-    public void shutdownNow() {
-        jobQueue.stopQueue();
+    public boolean shutdownNow() {
+        return jobQueue.stopQueue();
     }
 
     public boolean isStarted() {


### PR DESCRIPTION
This depends on https://github.com/killbill/killbill-commons/pull/97.

I was able to verify the behavior by running a few tests and configuring various `org.killbill.notificationq.analytics.shutdownTimeout` values in Kill Bill.
