### PR TITLE
Bundle optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ curl -v \
   blacklist:
     - 468e5259-6635-4988-9ae7-3d79b11fc6ed
     - f7da09af-8593-4a88-b6d4-1c4ebf807103
+  highCardinalityAccounts:
+    - a8e594e5-1b78-4c2d-876b-f09ec36c611c
+    - 31ea22c7-19ae-4316-a432-5e6319e49f97
   ignoredGroups:
     - FIELDS
   pluginPropertyKeys:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ org.killbill.notificationq.analytics.historyTableName=analytics_notifications_hi
 org.killbill.analytics.lockSleepMilliSeconds=100
 ```
 
+### Notes
+
+When `enablePartialRefreshes` is set (default), some features are disabled, namely:
+
+* `analytics_bundles.bundle_account_rank` cannot be computed
+
+When `highCardinalityAccounts` is configured, some features are disabled, namely:
+
+* `analytics_accounts.nb_active_bundles` is not computed for that account
+
 ## Setup
 
 Default dashboards rely on reports that need to be installed by running the [seed_reports.sh](https://github.com/killbill/killbill-analytics-plugin/blob/master/src/main/resources/seed_reports.sh) script.

--- a/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsListener.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsListener.java
@@ -354,7 +354,7 @@ public class AnalyticsListener implements OSGIKillbillEventDispatcher.OSGIKillbi
                 allBusinessObjectsDao.update(businessContextFactory);
                 break;
             case SUBSCRIPTIONS:
-                bstDao.update(businessContextFactory);
+                bstDao.update(job.getObjectId(), job.getObjectType(), businessContextFactory);
                 break;
             case OVERDUE:
                 bosDao.update(businessContextFactory);

--- a/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
@@ -54,6 +54,8 @@ public class AnalyticsConfiguration {
     // Whether to allow template variables in raw SQL queries.
     // Note! This could be prone to SQL injection and should only be enabled in trusted environments.
     public boolean enableTemplateVariables = false;
+    // List of account ids with a high cardinality (where queries by account_record_id is a bad idea)
+    public List<String> highCardinalityAccounts = new LinkedList<String>();
 
     public Map<String, Map<Integer, String>> pluginPropertyKeys = new HashMap<String, Map<Integer, String>>();
     public Map<String, Map<String, String>> databases = new HashMap<String, Map<String, String>>();

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessAnalyticsSqlDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessAnalyticsSqlDao.java
@@ -68,6 +68,12 @@ public interface BusinessAnalyticsSqlDao extends Transactional<BusinessAnalytics
                        final CallContext callContext);
 
     @SqlUpdate
+    public void deleteByBundleId(@Define("tableName") final String tableName,
+                                 @Bind("bundleId") final UUID bundleId,
+                                 @Bind("tenantRecordId") final Long tenantRecordId,
+                                 final CallContext callContext);
+
+    @SqlUpdate
     public void deleteByInvoiceId(@Define("tableName") final String tableName,
                                   @Bind("invoiceId") final UUID invoiceId,
                                   @Bind("tenantRecordId") final Long tenantRecordId,

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessBundleDao.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/BusinessBundleDao.java
@@ -19,8 +19,6 @@
 
 package org.killbill.billing.plugin.analytics.dao;
 
-import java.util.Collection;
-
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
 import org.killbill.billing.plugin.analytics.dao.model.BusinessBundleModelDao;
 import org.killbill.billing.util.callcontext.CallContext;
@@ -31,17 +29,17 @@ public class BusinessBundleDao extends BusinessAnalyticsDaoBase {
         super(osgiKillbillDataSource);
     }
 
-    public void updateInTransaction(final Collection<BusinessBundleModelDao> bbss,
-                                    final Long accountRecordId,
+    public void updateInTransaction(final Iterable<BusinessBundleModelDao> bbss,
                                     final Long tenantRecordId,
                                     final BusinessAnalyticsSqlDao transactional,
                                     final CallContext context) {
-        transactional.deleteByAccountRecordId(BusinessBundleModelDao.BUNDLES_TABLE_NAME,
-                                              accountRecordId,
-                                              tenantRecordId,
-                                              context);
-
         for (final BusinessBundleModelDao bbs : bbss) {
+            // Delete by bundle to support partial refreshes
+            transactional.deleteByBundleId(BusinessBundleModelDao.BUNDLES_TABLE_NAME,
+                                           bbs.getBundleId(),
+                                           tenantRecordId,
+                                           context);
+
             transactional.create(bbs.getTableName(), bbs, context);
         }
 

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessAccountFactory.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessAccountFactory.java
@@ -21,8 +21,6 @@ package org.killbill.billing.plugin.analytics.dao.factory;
 
 import java.math.BigDecimal;
 
-import javax.annotation.Nullable;
-
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.entitlement.api.Entitlement.EntitlementState;
@@ -77,8 +75,9 @@ public class BusinessAccountFactory {
 
         // Retrieve bundles information
         final Iterable<SubscriptionBundle> bundles = businessContextFactory.getAccountBundles();
-
-        final int nbActiveBundles = Iterables.size(Iterables.<SubscriptionBundle>filter(bundles,
+        // Skip this call for large accounts
+        final int nbActiveBundles = businessContextFactory.highCardinalityAccount() ? -1 :
+                                    Iterables.size(Iterables.<SubscriptionBundle>filter(bundles,
                                                                                         new Predicate<SubscriptionBundle>() {
                                                                                             @Override
                                                                                             public boolean apply(final SubscriptionBundle bundle) {

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessBundleFactory.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessBundleFactory.java
@@ -32,8 +32,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorCompletionService;
 
-import javax.annotation.Nullable;
-
 import org.joda.time.LocalDate;
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.catalog.api.ProductCategory;
@@ -71,12 +69,10 @@ public class BusinessBundleFactory {
 
         // Lookup once all SubscriptionBundle for that account (this avoids expensive lookups for each bundle)
         final Set<UUID> baseSubscriptionIds = new HashSet<UUID>();
-        final Map<UUID, SubscriptionBundle> bundles = new LinkedHashMap<UUID, SubscriptionBundle>();
         final Iterable<SubscriptionBundle> bundlesForAccount = businessContextFactory.getAccountBundles();
         for (final SubscriptionBundle bundle : bundlesForAccount) {
             for (final Subscription subscription : bundle.getSubscriptions()) {
                 baseSubscriptionIds.add(subscription.getBaseEntitlementId());
-                bundles.put(bundle.getId(), bundle);
             }
         }
 
@@ -98,7 +94,6 @@ public class BusinessBundleFactory {
                                     account,
                                     creationAuditLog,
                                     accountRecordId,
-                                    bundles,
                                     bst,
                                     rankForBundle.get(bst.getBundleId()),
                                     currencyConverter,
@@ -147,13 +142,12 @@ public class BusinessBundleFactory {
                                             final Account account,
                                             final AuditLog creationAuditLog,
                                             final Long accountRecordId,
-                                            final Map<UUID, SubscriptionBundle> bundles,
                                             final BusinessSubscriptionTransitionModelDao bst,
                                             final Integer bundleAccountRank,
                                             final CurrencyConverter currencyConverter,
                                             final Long tenantRecordId,
                                             final ReportGroup reportGroup) throws AnalyticsRefreshException {
-        final SubscriptionBundle bundle = bundles.get(bst.getBundleId());
+        final SubscriptionBundle bundle = businessContextFactory.getSubscriptionBundle(bst.getBundleId());
         final Long bundleRecordId = businessContextFactory.getBundleRecordId(bundle.getId());
         final Boolean latestForBundleExternalKey = businessContextFactory.getLatestSubscriptionBundleForExternalKey(bundle.getExternalKey()).getId().equals(bundle.getId());
 

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessContextFactory.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessContextFactory.java
@@ -54,6 +54,7 @@ import org.killbill.clock.Clock;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
@@ -72,7 +73,7 @@ public class BusinessContextFactory extends BusinessFactoryBase {
     private volatile Account account;
     private volatile Account parentAccount;
     private volatile BigDecimal accountBalance;
-    // Relatively cheap lookups, should be done by account_record_id
+    // Relatively cheap lookups (assuming low cardinality), should be done by account_record_id
     private volatile Iterable<SubscriptionBundle> accountBundles;
     private volatile Iterable<SubscriptionEvent> accountBlockingStates;
     private volatile Map<UUID, Invoice> invoices = new HashMap<UUID, Invoice>();
@@ -105,6 +106,7 @@ public class BusinessContextFactory extends BusinessFactoryBase {
     private volatile Map<UUID, Long> tagRecordIds = new HashMap<UUID, Long>();
     private volatile Map<UUID, Long> customFieldRecordIds = new HashMap<UUID, Long>();
     // Others
+    private volatile Map<UUID, SubscriptionBundle> cachedBundles = new HashMap<UUID, SubscriptionBundle>();
     private volatile Map<String, SubscriptionBundle> latestSubscriptionBundleForExternalKeys = new HashMap<String, SubscriptionBundle>();
     private volatile Map<UUID, TagDefinition> tagDefinitions = new HashMap<UUID, TagDefinition>();
     private volatile VersionedCatalog catalog;
@@ -210,9 +212,10 @@ public class BusinessContextFactory extends BusinessFactoryBase {
             synchronized (this) {
                 if (accountBundles == null) {
                     accountBundles = getSubscriptionBundlesForAccount(accountId, callContext);
-
-                    // Pre-populate latestSubscriptionBundleForExternalKeys cache to avoid calling getLatestSubscriptionBundleForExternalKey for each bundle
                     for (final SubscriptionBundle subscriptionBundle : accountBundles) {
+                        cachedBundles.put(subscriptionBundle.getId(), subscriptionBundle);
+
+                        // Pre-populate latestSubscriptionBundleForExternalKeys cache to avoid calling getLatestSubscriptionBundleForExternalKey for each bundle
                         if (latestSubscriptionBundleForExternalKeys.get(subscriptionBundle.getExternalKey()) == null ||
                             latestSubscriptionBundleForExternalKeys.get(subscriptionBundle.getExternalKey()).getCreatedDate().compareTo(subscriptionBundle.getCreatedDate()) > 0) {
                             latestSubscriptionBundleForExternalKeys.put(subscriptionBundle.getExternalKey(), subscriptionBundle);
@@ -581,6 +584,24 @@ public class BusinessContextFactory extends BusinessFactoryBase {
             }
         }
         return customFieldRecordIds.get(customFieldId);
+    }
+
+    public SubscriptionBundle getSubscriptionBundle(final UUID bundleId) throws AnalyticsRefreshException {
+        if (cachedBundles.get(bundleId) == null) {
+            synchronized (this) {
+                if (cachedBundles.get(bundleId) == null) {
+                    final AnalyticsConfiguration analyticsConfiguration = analyticsConfigurationHandler.getConfigurable(callContext.getTenantId());
+                    if (Iterables.find(analyticsConfiguration.highCardinalityAccounts, Predicates.<String>equalTo(accountId.toString()), null) != null) {
+                        // Avoid per account query
+                        cachedBundles.put(bundleId, getSubscriptionBundle(bundleId, callContext));
+                    } else {
+                        // Populate the accountBundles cache, which will cache the second cachedBundles one
+                        getAccountBundles();
+                    }
+                }
+            }
+        }
+        return cachedBundles.get(bundleId);
     }
 
     public SubscriptionBundle getLatestSubscriptionBundleForExternalKey(final String externalKey) throws AnalyticsRefreshException {

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessFactoryBase.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessFactoryBase.java
@@ -37,6 +37,7 @@ import org.killbill.billing.catalog.api.CatalogUserApi;
 import org.killbill.billing.catalog.api.Plan;
 import org.killbill.billing.catalog.api.PlanPhase;
 import org.killbill.billing.catalog.api.VersionedCatalog;
+import org.killbill.billing.entitlement.api.Subscription;
 import org.killbill.billing.entitlement.api.SubscriptionApi;
 import org.killbill.billing.entitlement.api.SubscriptionApiException;
 import org.killbill.billing.entitlement.api.SubscriptionBundle;
@@ -231,6 +232,17 @@ public abstract class BusinessFactoryBase {
             return bundles.get(bundles.size() - 1);
         } catch (final SubscriptionApiException e) {
             logger.warn("Error retrieving bundles for bundle external key {}", bundleExternalKey, e);
+            throw new AnalyticsRefreshException(e);
+        }
+    }
+
+    protected Subscription getSubscription(final UUID subscriptionId, final TenantContext context) throws AnalyticsRefreshException {
+        final SubscriptionApi subscriptionApi = getSubscriptionApi();
+
+        try {
+            return subscriptionApi.getSubscriptionForEntitlementId(subscriptionId, context);
+        } catch (final SubscriptionApiException e) {
+            logger.warn("Error retrieving subscription for id {}", subscriptionId, e);
             throw new AnalyticsRefreshException(e);
         }
     }

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessFieldFactory.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessFieldFactory.java
@@ -20,10 +20,7 @@
 package org.killbill.billing.plugin.analytics.dao.factory;
 
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
-import java.util.Map;
-import java.util.UUID;
 
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.account.api.Account;
@@ -46,14 +43,6 @@ public class BusinessFieldFactory {
 
         final Iterable<CustomField> fields = businessContextFactory.getAccountCustomFields();
 
-        // Lookup once all SubscriptionBundle for that account (optimized call, should be faster in case an account has a lot
-        // of bundles with custom fields)
-        final Iterable<SubscriptionBundle> bundlesForAccount = businessContextFactory.getAccountBundles();
-        final Map<UUID, SubscriptionBundle> bundles = new LinkedHashMap<UUID, SubscriptionBundle>();
-        for (final SubscriptionBundle bundle : bundlesForAccount) {
-            bundles.put(bundle.getId(), bundle);
-        }
-
         final Collection<BusinessFieldModelDao> fieldModelDaos = new LinkedList<BusinessFieldModelDao>();
         // We process custom fields sequentially: in practice, an account will be associated with a dozen fields at most
         for (final CustomField field : fields) {
@@ -62,7 +51,7 @@ public class BusinessFieldFactory {
 
             SubscriptionBundle bundle = null;
             if (ObjectType.BUNDLE.equals(field.getObjectType())) {
-                bundle = bundles.get(field.getObjectId());
+                bundle = businessContextFactory.getSubscriptionBundle(field.getObjectId());
             }
             final BusinessFieldModelDao fieldModelDao = BusinessFieldModelDao.create(account,
                                                                                      accountRecordId,

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessInvoiceFactory.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessInvoiceFactory.java
@@ -91,13 +91,6 @@ public class BusinessInvoiceFactory {
         // Lookup the invoice
         final Invoice invoice = businessContextFactory.getInvoice(invoiceId);
 
-        // Lookup all SubscriptionBundle for that account (this avoids expensive lookups for each item)
-        final Iterable<SubscriptionBundle> bundlesForAccount = businessContextFactory.getAccountBundles();
-        final Map<UUID, SubscriptionBundle> bundles = new LinkedHashMap<UUID, SubscriptionBundle>();
-        for (final SubscriptionBundle bundle : bundlesForAccount) {
-            bundles.put(bundle.getId(), bundle);
-        }
-
         final Iterable<Tag> tags = businessContextFactory.getAccountTags();
         final Set<UUID> writtenOffInvoices = new HashSet<UUID>();
         for (final Tag cur : tags) {
@@ -150,7 +143,6 @@ public class BusinessInvoiceFactory {
                                                                                                           otherInvoiceItems,
                                                                                                           linkedInvoiceItem,
                                                                                                           isWrittenOff,
-                                                                                                          bundles,
                                                                                                           currencyConverter,
                                                                                                           creationAuditLog,
                                                                                                           accountRecordId,
@@ -203,13 +195,6 @@ public class BusinessInvoiceFactory {
             allInvoiceItems.get(invoice.getId()).addAll(invoice.getInvoiceItems());
         }
 
-        // Lookup once all SubscriptionBundle for that account (this avoids expensive lookups for each item)
-        final Iterable<SubscriptionBundle> bundlesForAccount = businessContextFactory.getAccountBundles();
-        final Map<UUID, SubscriptionBundle> bundles = new LinkedHashMap<UUID, SubscriptionBundle>();
-        for (final SubscriptionBundle bundle : bundlesForAccount) {
-            bundles.put(bundle.getId(), bundle);
-        }
-
         final Iterable<Tag> tags = businessContextFactory.getAccountTags();
         final Set<UUID> writtenOffInvoices = new HashSet<UUID>();
         for (final Tag cur : tags) {
@@ -236,7 +221,6 @@ public class BusinessInvoiceFactory {
                                                      invoiceIdToInvoiceMappings,
                                                      isWrittenOff,
                                                      account,
-                                                     bundles,
                                                      currencyConverter,
                                                      creationAuditLog,
                                                      accountRecordId,
@@ -315,7 +299,6 @@ public class BusinessInvoiceFactory {
                                                                       final Map<UUID, Invoice> invoiceIdToInvoiceMappings,
                                                                       final boolean isWrittenOff,
                                                                       final Account account,
-                                                                      final Map<UUID, SubscriptionBundle> bundles,
                                                                       final CurrencyConverter currencyConverter,
                                                                       final AuditLog creationAuditLog,
                                                                       final Long accountRecordId,
@@ -346,7 +329,6 @@ public class BusinessInvoiceFactory {
                                          otherInvoiceItems,
                                          linkedInvoiceItem,
                                          isWrittenOff,
-                                         bundles,
                                          currencyConverter,
                                          creationAuditLog,
                                          accountRecordId,
@@ -363,7 +345,6 @@ public class BusinessInvoiceFactory {
                                                               // For convenience, populate empty columns using the linked item
                                                               @Nullable final InvoiceItem linkedInvoiceItem,
                                                               final boolean isWrittenOff,
-                                                              final Map<UUID, SubscriptionBundle> bundles,
                                                               final CurrencyConverter currencyConverter,
                                                               final AuditLog creationAuditLog,
                                                               final Long accountRecordId,
@@ -372,10 +353,10 @@ public class BusinessInvoiceFactory {
         SubscriptionBundle bundle = null;
         // Subscription and bundle could be null for e.g. credits or adjustments
         if (invoiceItem.getBundleId() != null) {
-            bundle = bundles.get(invoiceItem.getBundleId());
+            bundle = businessContextFactory.getSubscriptionBundle(invoiceItem.getBundleId());
         }
         if (bundle == null && linkedInvoiceItem != null && linkedInvoiceItem.getBundleId() != null) {
-            bundle = bundles.get(linkedInvoiceItem.getBundleId());
+            bundle = businessContextFactory.getSubscriptionBundle(linkedInvoiceItem.getBundleId());
         }
 
         Plan plan = null;

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessSubscriptionTransitionFactory.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessSubscriptionTransitionFactory.java
@@ -41,6 +41,7 @@ import org.killbill.billing.plugin.analytics.utils.CurrencyConverter;
 import org.killbill.billing.util.audit.AuditLog;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 
 public class BusinessSubscriptionTransitionFactory {
 
@@ -50,14 +51,24 @@ public class BusinessSubscriptionTransitionFactory {
     public static final String BILLING_SERVICE_NAME = "billing-service";
     public static final String ENTITLEMENT_BILLING_SERVICE_NAME = "entitlement+billing-service";
 
+    public Collection<BusinessSubscriptionTransitionModelDao> createBusinessSubscriptionTransitions(final UUID bundleId,
+                                                                                                    final BusinessContextFactory businessContextFactory) throws AnalyticsRefreshException {
+        final SubscriptionBundle bundle = businessContextFactory.getSubscriptionBundle(bundleId);
+        return createBusinessSubscriptionTransitions(ImmutableList.<SubscriptionBundle>of(bundle), businessContextFactory);
+    }
+
     public Collection<BusinessSubscriptionTransitionModelDao> createBusinessSubscriptionTransitions(final BusinessContextFactory businessContextFactory) throws AnalyticsRefreshException {
+        final Iterable<SubscriptionBundle> bundles = businessContextFactory.getAccountBundles();
+        return createBusinessSubscriptionTransitions(bundles, businessContextFactory);
+    }
+
+    private Collection<BusinessSubscriptionTransitionModelDao> createBusinessSubscriptionTransitions(final Iterable<SubscriptionBundle> bundles,
+                                                                                                     final BusinessContextFactory businessContextFactory) throws AnalyticsRefreshException {
         final Account account = businessContextFactory.getAccount();
         final Long accountRecordId = businessContextFactory.getAccountRecordId();
         final Long tenantRecordId = businessContextFactory.getTenantRecordId();
         final ReportGroup reportGroup = businessContextFactory.getReportGroup();
         final CurrencyConverter currencyConverter = businessContextFactory.getCurrencyConverter();
-
-        final Iterable<SubscriptionBundle> bundles = businessContextFactory.getAccountBundles();
 
         final Collection<BusinessSubscriptionTransitionModelDao> bsts = new LinkedList<BusinessSubscriptionTransitionModelDao>();
         for (final SubscriptionBundle bundle : bundles) {

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessTagFactory.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessTagFactory.java
@@ -47,14 +47,6 @@ public class BusinessTagFactory {
 
         final Iterable<Tag> tags = businessContextFactory.getAccountTags();
 
-        // Lookup once all SubscriptionBundle for that account (optimized call, should be faster in case an account has a lot
-        // of tagged bundles)
-        final Iterable<SubscriptionBundle> bundlesForAccount = businessContextFactory.getAccountBundles();
-        final Map<UUID, SubscriptionBundle> bundles = new LinkedHashMap<UUID, SubscriptionBundle>();
-        for (final SubscriptionBundle bundle : bundlesForAccount) {
-            bundles.put(bundle.getId(), bundle);
-        }
-
         final Collection<BusinessTagModelDao> tagModelDaos = new LinkedList<BusinessTagModelDao>();
         // We process tags sequentially: in practice, an account will be associated with a dozen tags at most
         for (final Tag tag : tags) {
@@ -64,7 +56,7 @@ public class BusinessTagFactory {
 
             SubscriptionBundle bundle = null;
             if (ObjectType.BUNDLE.equals(tag.getObjectType())) {
-                bundle = bundles.get(tag.getObjectId());
+                bundle = businessContextFactory.getSubscriptionBundle(tag.getObjectId());
             }
             final BusinessTagModelDao tagModelDao = BusinessTagModelDao.create(account,
                                                                                accountRecordId,

--- a/src/main/resources/org/killbill/billing/plugin/analytics/dao/BusinessAnalyticsSqlDao.sql.stg
+++ b/src/main/resources/org/killbill/billing/plugin/analytics/dao/BusinessAnalyticsSqlDao.sql.stg
@@ -2257,6 +2257,13 @@ from <table> t
 where <CHECK_TENANT_AND_ACCOUNT("t.")>
 >>
 
+deleteByBundleId(tableName) ::= <<
+delete from <tableName>
+where <CHECK_TENANT("")>
+and bundle_id = :bundleId
+;
+>>
+
 deleteByInvoiceId(tableName) ::= <<
 delete from <tableName>
 where <CHECK_TENANT("")>

--- a/src/test/java/org/killbill/billing/plugin/analytics/dao/factory/TestBusinessInvoiceFactory.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/dao/factory/TestBusinessInvoiceFactory.java
@@ -99,7 +99,6 @@ public class TestBusinessInvoiceFactory extends AnalyticsTestSuiteNoDB {
                                                                                                       ImmutableList.<InvoiceItem>of(taxItem, recurringItem),
                                                                                                       recurringItem,
                                                                                                       false,
-                                                                                                      bundles,
                                                                                                       currencyConverter,
                                                                                                       auditLog,
                                                                                                       accountRecordId,


### PR DESCRIPTION
* New `highCardinalityAccounts` property to optimize codepaths for accounts where we shouldn't do per account queries
* Enable partial refresh of bundles and subscriptions (https://github.com/killbill/killbill-analytics-plugin/issues/93)