### PR TITLE
Fixed encoding issue for non-acii characters in CSV response for repo…

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/analytics/http/ReportsResource.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/http/ReportsResource.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
@@ -189,9 +190,9 @@ public class ReportsResource extends BaseResource {
 
             final String format = formatter.orElse(JSON_DATA_FORMAT);
             if (CSV_DATA_FORMAT.equals(format)) {
-                final OutputStream out = new ByteArrayOutputStream();
+                final ByteArrayOutputStream out = new ByteArrayOutputStream();
                 writeAsCSV(results, out);
-                return Results.with(out, Status.OK).header("Content-Type", "text/csv");
+                return Results.with(out.toString(StandardCharsets.UTF_8.name()), Status.OK).header("Content-Type", "text/csv; charset=utf-8");
             } else {
                 return Results.with(results, Status.OK).header("Content-Type", "application/json");
             }

--- a/src/test/java/org/killbill/billing/plugin/analytics/http/TestReportsServlet.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/http/TestReportsServlet.java
@@ -100,7 +100,7 @@ public class TestReportsServlet extends AnalyticsTestSuiteNoDB {
         values.add(Arrays.asList("2013-01-01", " ", 7.0));
         values.add(Arrays.asList("2013-01-01", " ", null));
         values.add(Arrays.asList("2013-01-01", " ", ""));
-        values.add(Arrays.asList("2013-01-01", "something", null));
+        values.add(Arrays.asList("2013-01-01", "something’s", null));
         values.add(Arrays.asList("2013-01-01", "something", ""));
         values.add(Arrays.asList("2013-01-01", "something", " "));
         final DataMarker serie1 = new TableDataSeries("serie1",
@@ -117,7 +117,7 @@ public class TestReportsServlet extends AnalyticsTestSuiteNoDB {
                             "2013-01-01,\" \",7.0\n" +
                             "2013-01-01,\" \",\n" +
                             "2013-01-01,\" \",\n" +
-                            "2013-01-01,something,\n" +
+                            "2013-01-01,something’s,\n" +
                             "2013-01-01,something,\n" +
                             "2013-01-01,something,\" \"\n"
                            );

--- a/src/test/java/org/killbill/billing/plugin/analytics/http/TestReportsServlet.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/http/TestReportsServlet.java
@@ -100,8 +100,8 @@ public class TestReportsServlet extends AnalyticsTestSuiteNoDB {
         values.add(Arrays.asList("2013-01-01", " ", 7.0));
         values.add(Arrays.asList("2013-01-01", " ", null));
         values.add(Arrays.asList("2013-01-01", " ", ""));
-        values.add(Arrays.asList("2013-01-01", "something’s", null));
-        values.add(Arrays.asList("2013-01-01", "something", ""));
+        values.add(Arrays.asList("2013-01-01", "何か", null));
+        values.add(Arrays.asList("2013-01-01", "dóndé", ""));
         values.add(Arrays.asList("2013-01-01", "something", " "));
         final DataMarker serie1 = new TableDataSeries("serie1",
                                                       ImmutableList.<String>of("c1", "c2", "c3"),
@@ -117,8 +117,8 @@ public class TestReportsServlet extends AnalyticsTestSuiteNoDB {
                             "2013-01-01,\" \",7.0\n" +
                             "2013-01-01,\" \",\n" +
                             "2013-01-01,\" \",\n" +
-                            "2013-01-01,something’s,\n" +
-                            "2013-01-01,something,\n" +
+                            "2013-01-01,何か,\n" +
+                            "2013-01-01,dóndé,\n" +
                             "2013-01-01,something,\" \"\n"
                            );
     }


### PR DESCRIPTION
This PR fixes encoding issue in CSV data generated by `/reports` API. 

UTF-8 encoded string is being sent in response now which fixed the issue.

Tested end-end by pointing kaui-analytics-ui to these changes and making sure the csv generated shows correctly.
Tested by hitting the /reports API locally(with changes) and making sure responses correct output
