### PR TITLE
Oss 552 update parent and testing db server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
     uses: killbill/gh-actions-shared/.github/workflows/integration_test.yml@main
     with:
       plugin_name: 'analytics'
-      integration_tests_goal: 'ci:analytics'
+      integration_tests_goal: 'test:plugins:analytics'
       ddl_file: 'src/main/resources/org/killbill/billing/plugin/analytics/ddl.sql'
       integration_tests_ref: 'refs/heads/work-for-release-0.23.x'

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.145.3-70b31ce-SNAPSHOT</version>
+        <version>0.145.3-8ff3c94-SNAPSHOT</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>analytics-plugin</artifactId>
@@ -100,16 +100,6 @@
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>
-            <artifactId>testing-mysql-server</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>testing-postgresql-server</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
             <scope>test</scope>
         </dependency>
@@ -117,6 +107,11 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-jdbc</artifactId>
             <version>354</version>
+        </dependency>
+        <dependency>
+            <groupId>io.zonky.test</groupId>
+            <artifactId>embedded-postgres</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
@@ -261,6 +256,11 @@
         <dependency>
             <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-queue</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.testing</groupId>
+            <artifactId>testing-mysql-server</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessFactoryBase.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/dao/factory/BusinessFactoryBase.java
@@ -226,7 +226,7 @@ public abstract class BusinessFactoryBase {
 
         try {
             final List<SubscriptionBundle> bundles = subscriptionApi.getSubscriptionBundlesForExternalKey(bundleExternalKey, context);
-            if (bundles.size() == 0) {
+            if (bundles.isEmpty()) {
                 throw new AnalyticsRefreshException("Unable to retrieve latest bundle for bundle external key " + bundleExternalKey);
             }
             return bundles.get(bundles.size() - 1);
@@ -240,7 +240,7 @@ public abstract class BusinessFactoryBase {
         final SubscriptionApi subscriptionApi = getSubscriptionApi();
 
         try {
-            return subscriptionApi.getSubscriptionForEntitlementId(subscriptionId, context);
+            return subscriptionApi.getSubscriptionForEntitlementId(subscriptionId, false, context);
         } catch (final SubscriptionApiException e) {
             logger.warn("Error retrieving subscription for id {}", subscriptionId, e);
             throw new AnalyticsRefreshException(e);

--- a/src/test/java/org/killbill/billing/plugin/analytics/AnalyticsTestSuiteNoDB.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/AnalyticsTestSuiteNoDB.java
@@ -261,12 +261,12 @@ public abstract class AnalyticsTestSuiteNoDB {
     }
 
     @BeforeSuite(alwaysRun = true)
-    public void setUpBeforeSuite() throws Exception {
+    public void setUpBeforeSuite() {
         System.setProperty("org.jooq.no-logo", "true");
         System.setProperty("org.jooq.no-tips", "true");
     }
 
-    @BeforeMethod(groups = "fast")
+    @BeforeMethod(groups = {"fast", "slow"})
     public void setUp() throws Exception {
         Mockito.when(currencyConverter.getConvertedCurrency()).thenReturn("USD");
         Mockito.when(currencyConverter.getConvertedValue(Mockito.<BigDecimal>any(), Mockito.anyString(), Mockito.<LocalDate>any())).thenReturn(BigDecimal.TEN);


### PR DESCRIPTION
Some important notes: add "slow" group to [`@BeforeMethod`](https://github.com/killbill/killbill-analytics-plugin/commit/89c464b9eb256743e3deea37d101212a1c28d292). 

needed because even by default the test is not pass and have a lot of `NullPointerException`. This is because `AnalyticsTestSuiteWithEmbeddedDB` extends `AnalyticsTestSuiteNoDB`, but the `@BeforeMethod(groups='slow')` is not available for `AnalyticsTestSuiteWithEmbeddedDB`.

If we need to take another way, let me know.