### PR TITLE
Work for 161

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,21 @@ org.killbill.notificationq.analytics.historyTableName=analytics_notifications_hi
 org.killbill.analytics.lockSleepMilliSeconds=100
 ```
 
+In addition, the following per-tenant properties can also be configured globally:
+
+````
+org.killbill.billing.plugin.analytics.blacklist=468e5259-6635-4988-9ae7-3d79b11fc6ed,f7da09af-8593-4a88-b6d4-1c4ebf807103
+org.killbill.billing.plugin.analytics.ignoredGroups=FIELDS
+org.killbill.billing.plugin.analytics.highCardinalityAccounts=a8e594e5-1b78-4c2d-876b-f09ec36c611c,31ea22c7-19ae-4316-a432-5e6319e49f97
+org.killbill.billing.plugin.analytics.refreshDelaySeconds=10
+org.killbill.billing.plugin.analytics.lockAttemptRetries=100
+org.killbill.billing.plugin.analytics.rescheduleIntervalOnLockSeconds=10
+org.killbill.billing.plugin.analytics.enablePartialRefreshes=true
+org.killbill.billing.plugin.analytics.enableTemplateVariables=false
+````
+
+Note that the per-tenant configuration always takes precedence. So, the global properties only serve as defaults when a per-tenant configuration is not specified. 
+
 See [Plugin Configuration](https://docs.killbill.io/latest/userguide_analytics.html#_plugin_configuration) for further information. 
 
 ## Setup

--- a/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsActivator.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/AnalyticsActivator.java
@@ -73,6 +73,7 @@ public class AnalyticsActivator extends KillbillActivatorBase {
 
     public static final String PLUGIN_NAME = "killbill-analytics";
     public static final String ANALYTICS_QUEUE_SERVICE = "AnalyticsService";
+    public static final String PROPERTY_PREFIX = "org.killbill.billing.plugin.analytics.";
     private static final Logger logger = LoggerFactory.getLogger(AnalyticsActivator.class);
     private AnalyticsConfigurationHandler analyticsConfigurationHandler;
     private AnalyticsListener analyticsListener;
@@ -106,7 +107,7 @@ public class AnalyticsActivator extends KillbillActivatorBase {
         final String region = PluginEnvironmentConfig.getRegion(configProperties.getProperties());
 
         analyticsConfigurationHandler = new AnalyticsConfigurationHandler(region, PLUGIN_NAME, roOSGIkillbillAPI);
-        analyticsConfigurationHandler.setDefaultConfigurable(new AnalyticsConfiguration());
+        analyticsConfigurationHandler.setDefaultConfigurable(new AnalyticsConfiguration(configProperties.getProperties()));
 
         // Timeout defines how long to sleep between retries to get the lock
         final long lockSleepMilliSeconds = Long.parseLong(configProperties.getProperties().getProperty("org.killbill.analytics.lockSleepMilliSeconds", "100"));

--- a/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
@@ -36,26 +36,27 @@ public class AnalyticsConfiguration {
 
     public AnalyticsConfiguration() {
 
+        this.blacklist = new LinkedList<String>();
+        this.ignoredGroups = new LinkedList<String>();
+        this.refreshDelaySeconds = 10;
+        this.lockAttemptRetries = 100;
+        this.rescheduleIntervalOnLockSeconds = 10;
+        this.enablePartialRefreshes = true;
+        this.enableTemplateVariables = false;
+        this.highCardinalityAccounts = new LinkedList<String>();
+
     }
 
     public AnalyticsConfiguration(final Properties properties) {  //CTOR used only for default configuration from global properties if available
 
         String blackList = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "blacklist");
-
-        if (blackList != null && !blackList.isEmpty()) {
-            this.blacklist = Arrays.asList(blackList.split(","));
-        }
+        this.blacklist = blackList != null && !blackList.isEmpty() ? Arrays.asList(blackList.split(",")) : new LinkedList<String>();
 
         String ignoredGroups = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "ignoredGroups");
-        if (ignoredGroups != null && !ignoredGroups.isEmpty()) {
-            this.ignoredGroups = Arrays.asList(ignoredGroups.split(","));
-        }
+        this.ignoredGroups = ignoredGroups != null && !ignoredGroups.isEmpty() ? Arrays.asList(ignoredGroups.split(",")) : new LinkedList<String>();
 
         String highCardinalityAccounts = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "highCardinalityAccounts");
-        if (highCardinalityAccounts != null && !highCardinalityAccounts.isEmpty()) {
-            this.highCardinalityAccounts = Arrays.asList(highCardinalityAccounts.split(","));
-        }
-
+        this.highCardinalityAccounts = highCardinalityAccounts != null && !highCardinalityAccounts.isEmpty() ? Arrays.asList(highCardinalityAccounts.split(",")) : new LinkedList<String>();
 
         this.refreshDelaySeconds = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "refreshDelaySeconds") != null ? Integer.parseInt(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "refreshDelaySeconds")) : 10;
         this.lockAttemptRetries = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "lockAttemptRetries") != null ? Integer.parseInt(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "lockAttemptRetries")) : 100;
@@ -73,24 +74,24 @@ public class AnalyticsConfiguration {
                                                                                                     5, "paymentMethod");
 
     // List of account ids to ignore
-    public List<String> blacklist = new LinkedList<String>();
+    public final List<String> blacklist;
     // Groups to ignore for refresh, see https://github.com/killbill/killbill-analytics-plugin/issues/87
-    public List<String> ignoredGroups = new LinkedList<String>();
+    public final List<String> ignoredGroups;
     // Delay, in seconds, before starting to refresh data after an event is received. For workflows with lots of successive events
     // for a given account (e.g. create account, add payment method, create payment), this makes sure we have the latest state
     // when starting the refresh (since only the first event will trigger the refresh, all others are ignored).
-    public Integer refreshDelaySeconds = 10;
+    public final Integer refreshDelaySeconds;
     // How many retries to get the lock
-    public Integer lockAttemptRetries = 100;
+    public final Integer lockAttemptRetries;
     // If the lock is taken, how long until the job is rescheduled
-    public Integer rescheduleIntervalOnLockSeconds = 10;
+    public final Integer rescheduleIntervalOnLockSeconds;
     // Whether to trigger full refreshes each time
-    public boolean enablePartialRefreshes = true;
+    public final boolean enablePartialRefreshes;
     // Whether to allow template variables in raw SQL queries.
     // Note! This could be prone to SQL injection and should only be enabled in trusted environments.
-    public boolean enableTemplateVariables = false;
+    public boolean enableTemplateVariables; //TODO_161 not final as it causes compilation error, revisit
     // List of account ids with a high cardinality (where queries by account_record_id is a bad idea)
-    public List<String> highCardinalityAccounts = new LinkedList<String>();
+    public final List<String> highCardinalityAccounts;
 
     public Map<String, Map<Integer, String>> pluginPropertyKeys = new HashMap<String, Map<Integer, String>>();
     public Map<String, Map<String, String>> databases = new HashMap<String, Map<String, String>>();

--- a/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
@@ -64,11 +64,11 @@ public class AnalyticsConfiguration {
     public Map<String, Map<String, String>> databases = new HashMap<String, Map<String, String>>();
 
     public AnalyticsConfiguration() {
-        this (Collections.emptyList(), Collections.emptyList(), 10, 100, 10, true, false, Collections.emptyList());
+        this (new LinkedList<>(), new LinkedList<>(), 10, 100, 10, true, false, new LinkedList<>());
     }
 
     public AnalyticsConfiguration(final boolean enableTemplateVariables){
-        this(Collections.emptyList(), Collections.emptyList(), 10, 100, 10, true, enableTemplateVariables, Collections.emptyList());
+        this(new LinkedList<>(), new LinkedList<>(), 10, 100, 10, true, enableTemplateVariables, new LinkedList<>());
     }
 
     public AnalyticsConfiguration(final List<String> blacklist, final List<String> ignoredGroups, final int refreshDelaySeconds, final int lockAttemptRetries, final int rescheduleIntervalOnLockSeconds, final boolean enablePartialRefreshes, final boolean enableTemplateVariables, final List<String> highCardinalityAccounts) {
@@ -85,13 +85,13 @@ public class AnalyticsConfiguration {
     public AnalyticsConfiguration(final Properties properties) {  //CTOR used only for default configuration from global properties if available
 
         final String blackList = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "blacklist");
-        this.blacklist = blackList != null && !blackList.isEmpty() ? Arrays.asList(blackList.split(",")) : Collections.emptyList();
+        this.blacklist = blackList != null && !blackList.isEmpty() ? Arrays.asList(blackList.split(",")) : new LinkedList<>();
 
         final String ignoredGroups = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "ignoredGroups");
-        this.ignoredGroups = ignoredGroups != null && !ignoredGroups.isEmpty() ? Arrays.asList(ignoredGroups.split(",")) : Collections.emptyList();
+        this.ignoredGroups = ignoredGroups != null && !ignoredGroups.isEmpty() ? Arrays.asList(ignoredGroups.split(",")) : new LinkedList<>();
 
         final String highCardinalityAccounts = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "highCardinalityAccounts");
-        this.highCardinalityAccounts = highCardinalityAccounts != null && !highCardinalityAccounts.isEmpty() ? Arrays.asList(highCardinalityAccounts.split(",")) : Collections.emptyList();
+        this.highCardinalityAccounts = highCardinalityAccounts != null && !highCardinalityAccounts.isEmpty() ? Arrays.asList(highCardinalityAccounts.split(",")) : new LinkedList<>();
 
         this.refreshDelaySeconds = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "refreshDelaySeconds") != null ? Integer.parseInt(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "refreshDelaySeconds")) : 10;
         this.lockAttemptRetries = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "lockAttemptRetries") != null ? Integer.parseInt(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "lockAttemptRetries")) : 100;

--- a/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
@@ -19,16 +19,51 @@
 
 package org.killbill.billing.plugin.analytics.api.core;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+
+import org.killbill.billing.plugin.analytics.AnalyticsActivator;
 
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings("UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD")
 public class AnalyticsConfiguration {
+
+    public AnalyticsConfiguration() {
+
+    }
+
+    public AnalyticsConfiguration(final Properties properties) {  //CTOR used only for default configuration from global properties if available
+
+        String blackList = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "blacklist");
+
+        if (blackList != null && !blackList.isEmpty()) {
+            this.blacklist = Arrays.asList(blackList.split(","));
+        }
+
+        String ignoredGroups = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "ignoredGroups");
+        if (ignoredGroups != null && !ignoredGroups.isEmpty()) {
+            this.ignoredGroups = Arrays.asList(ignoredGroups.split(","));
+        }
+
+        String highCardinalityAccounts = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "highCardinalityAccounts");
+        if (highCardinalityAccounts != null && !highCardinalityAccounts.isEmpty()) {
+            this.highCardinalityAccounts = Arrays.asList(highCardinalityAccounts.split(","));
+        }
+
+
+        this.refreshDelaySeconds = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "refreshDelaySeconds") != null ? Integer.parseInt(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "refreshDelaySeconds")) : 10;
+        this.lockAttemptRetries = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "lockAttemptRetries") != null ? Integer.parseInt(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "lockAttemptRetries")) : 100;
+        this.rescheduleIntervalOnLockSeconds = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "rescheduleIntervalOnLockSeconds") != null ? Integer.parseInt(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "rescheduleIntervalOnLockSeconds")) : 10;
+        this.enablePartialRefreshes = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "enablePartialRefreshes") != null ? Boolean.parseBoolean(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "enablePartialRefreshes")) : true;
+        this.enableTemplateVariables = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "enableTemplateVariables") != null ? Boolean.parseBoolean(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "enableTemplateVariables")) : false;
+
+    }
 
     // Sane defaults (keys used by most official plugins)
     private final Map<Integer, String> defaultPluginPropertyKeys = ImmutableMap.<Integer, String>of(1, "processorResponse",

--- a/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
@@ -20,6 +20,7 @@
 package org.killbill.billing.plugin.analytics.api.core;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -33,45 +34,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings("UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD")
 public class AnalyticsConfiguration {
-
-    public AnalyticsConfiguration() {
-
-        this.blacklist = new LinkedList<String>();
-        this.ignoredGroups = new LinkedList<String>();
-        this.refreshDelaySeconds = 10;
-        this.lockAttemptRetries = 100;
-        this.rescheduleIntervalOnLockSeconds = 10;
-        this.enablePartialRefreshes = true;
-        this.enableTemplateVariables = false;
-        this.highCardinalityAccounts = new LinkedList<String>();
-
-    }
-
-    public AnalyticsConfiguration(final Properties properties) {  //CTOR used only for default configuration from global properties if available
-
-        String blackList = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "blacklist");
-        this.blacklist = blackList != null && !blackList.isEmpty() ? Arrays.asList(blackList.split(",")) : new LinkedList<String>();
-
-        String ignoredGroups = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "ignoredGroups");
-        this.ignoredGroups = ignoredGroups != null && !ignoredGroups.isEmpty() ? Arrays.asList(ignoredGroups.split(",")) : new LinkedList<String>();
-
-        String highCardinalityAccounts = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "highCardinalityAccounts");
-        this.highCardinalityAccounts = highCardinalityAccounts != null && !highCardinalityAccounts.isEmpty() ? Arrays.asList(highCardinalityAccounts.split(",")) : new LinkedList<String>();
-
-        this.refreshDelaySeconds = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "refreshDelaySeconds") != null ? Integer.parseInt(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "refreshDelaySeconds")) : 10;
-        this.lockAttemptRetries = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "lockAttemptRetries") != null ? Integer.parseInt(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "lockAttemptRetries")) : 100;
-        this.rescheduleIntervalOnLockSeconds = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "rescheduleIntervalOnLockSeconds") != null ? Integer.parseInt(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "rescheduleIntervalOnLockSeconds")) : 10;
-        this.enablePartialRefreshes = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "enablePartialRefreshes") != null ? Boolean.parseBoolean(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "enablePartialRefreshes")) : true;
-        this.enableTemplateVariables = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "enableTemplateVariables") != null ? Boolean.parseBoolean(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "enableTemplateVariables")) : false;
-
-    }
-
-    // Sane defaults (keys used by most official plugins)
-    private final Map<Integer, String> defaultPluginPropertyKeys = ImmutableMap.<Integer, String>of(1, "processorResponse",
-                                                                                                    2, "avsResultCode",
-                                                                                                    3, "cvvResultCode",
-                                                                                                    4, "payment_processor_account_id",
-                                                                                                    5, "paymentMethod");
 
     // List of account ids to ignore
     public final List<String> blacklist;
@@ -87,14 +49,57 @@ public class AnalyticsConfiguration {
     public final Integer rescheduleIntervalOnLockSeconds;
     // Whether to trigger full refreshes each time
     public final boolean enablePartialRefreshes;
-    // Whether to allow template variables in raw SQL queries.
-    // Note! This could be prone to SQL injection and should only be enabled in trusted environments.
-    public boolean enableTemplateVariables; //TODO_161 not final as it causes compilation error, revisit
     // List of account ids with a high cardinality (where queries by account_record_id is a bad idea)
     public final List<String> highCardinalityAccounts;
-
+    // Sane defaults (keys used by most official plugins)
+    private final Map<Integer, String> defaultPluginPropertyKeys = ImmutableMap.<Integer, String>of(1, "processorResponse",
+                                                                                                    2, "avsResultCode",
+                                                                                                    3, "cvvResultCode",
+                                                                                                    4, "payment_processor_account_id",
+                                                                                                    5, "paymentMethod");
+    // Whether to allow template variables in raw SQL queries.
+    // Note! This could be prone to SQL injection and should only be enabled in trusted environments.
+    public final boolean enableTemplateVariables;
     public Map<String, Map<Integer, String>> pluginPropertyKeys = new HashMap<String, Map<Integer, String>>();
     public Map<String, Map<String, String>> databases = new HashMap<String, Map<String, String>>();
+
+    public AnalyticsConfiguration() {
+        this (Collections.emptyList(), Collections.emptyList(), 10, 100, 10, true, false, Collections.emptyList());
+    }
+
+    public AnalyticsConfiguration(final boolean enableTemplateVariables){
+        this(Collections.emptyList(), Collections.emptyList(), 10, 100, 10, true, enableTemplateVariables, Collections.emptyList());
+    }
+
+    public AnalyticsConfiguration(final List<String> blacklist, final List<String> ignoredGroups, final int refreshDelaySeconds, final int lockAttemptRetries, final int rescheduleIntervalOnLockSeconds, final boolean enablePartialRefreshes, final boolean enableTemplateVariables, final List<String> highCardinalityAccounts) {
+        this.blacklist = blacklist;
+        this.ignoredGroups = ignoredGroups;
+        this.refreshDelaySeconds = refreshDelaySeconds;
+        this.lockAttemptRetries = lockAttemptRetries;
+        this.rescheduleIntervalOnLockSeconds = rescheduleIntervalOnLockSeconds;
+        this.enablePartialRefreshes = enablePartialRefreshes;
+        this.enableTemplateVariables = enableTemplateVariables;
+        this.highCardinalityAccounts = highCardinalityAccounts;
+    }
+
+    public AnalyticsConfiguration(final Properties properties) {  //CTOR used only for default configuration from global properties if available
+
+        final String blackList = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "blacklist");
+        this.blacklist = blackList != null && !blackList.isEmpty() ? Arrays.asList(blackList.split(",")) : Collections.emptyList();
+
+        final String ignoredGroups = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "ignoredGroups");
+        this.ignoredGroups = ignoredGroups != null && !ignoredGroups.isEmpty() ? Arrays.asList(ignoredGroups.split(",")) : Collections.emptyList();
+
+        final String highCardinalityAccounts = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "highCardinalityAccounts");
+        this.highCardinalityAccounts = highCardinalityAccounts != null && !highCardinalityAccounts.isEmpty() ? Arrays.asList(highCardinalityAccounts.split(",")) : Collections.emptyList();
+
+        this.refreshDelaySeconds = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "refreshDelaySeconds") != null ? Integer.parseInt(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "refreshDelaySeconds")) : 10;
+        this.lockAttemptRetries = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "lockAttemptRetries") != null ? Integer.parseInt(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "lockAttemptRetries")) : 100;
+        this.rescheduleIntervalOnLockSeconds = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "rescheduleIntervalOnLockSeconds") != null ? Integer.parseInt(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "rescheduleIntervalOnLockSeconds")) : 10;
+        this.enablePartialRefreshes = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "enablePartialRefreshes") == null || Boolean.parseBoolean(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "enablePartialRefreshes"));
+        this.enableTemplateVariables = properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "enableTemplateVariables") != null && Boolean.parseBoolean(properties.getProperty(AnalyticsActivator.PROPERTY_PREFIX + "enableTemplateVariables"));
+
+    }
 
     public String getPluginPropertyKey(final int position, final String pluginName) {
         if (pluginPropertyKeys.get(pluginName) == null || pluginPropertyKeys.get(pluginName).get(position) == null) {

--- a/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
+++ b/src/main/java/org/killbill/billing/plugin/analytics/api/core/AnalyticsConfiguration.java
@@ -32,7 +32,6 @@ import org.killbill.billing.plugin.analytics.AnalyticsActivator;
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-@SuppressFBWarnings("UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD")
 public class AnalyticsConfiguration {
 
     // List of account ids to ignore
@@ -67,7 +66,7 @@ public class AnalyticsConfiguration {
         this (new LinkedList<>(), new LinkedList<>(), 10, 100, 10, true, false, new LinkedList<>());
     }
 
-    public AnalyticsConfiguration(final boolean enableTemplateVariables){
+    public AnalyticsConfiguration(final boolean enableTemplateVariables) {
         this(new LinkedList<>(), new LinkedList<>(), 10, 100, 10, true, enableTemplateVariables, new LinkedList<>());
     }
 

--- a/src/test/java/org/killbill/billing/plugin/analytics/reports/TestSqlReportDataExtractor.java
+++ b/src/test/java/org/killbill/billing/plugin/analytics/reports/TestSqlReportDataExtractor.java
@@ -325,8 +325,7 @@ public class TestSqlReportDataExtractor extends AnalyticsTestSuiteNoDB {
                                                                           @Nullable final DateTime endDate,
                                                                           final boolean templatingEnabled) {
         final ReportSpecification reportSpecification = new ReportSpecification(rawReportName);
-        final AnalyticsConfiguration configurable = new AnalyticsConfiguration();
-        configurable.enableTemplateVariables = templatingEnabled;
+        final AnalyticsConfiguration configurable = new AnalyticsConfiguration(templatingEnabled);
         return new SqlReportDataExtractor(sourceQuery, reportSpecification, startDate, endDate, configurable, DBEngine.MYSQL, 1234L);
     }
 }


### PR DESCRIPTION
Fix for #161. Note that this fix only enables global configuration for simple properties (single values and lists specified as comma-separated values). Complex properties like `pluginPropertyKeys` and `databases` still need to be configured via the per-tenant configuration.